### PR TITLE
Python Type Annotations

### DIFF
--- a/.github/workflows/python_ci.yml
+++ b/.github/workflows/python_ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5]
+        python-version: [3.6]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -26,9 +26,10 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r Python-packages/covidcast-py/requirements.txt
-    - name: Lint with pylint
+    - name: Lint with pylint and mypy
       run: |
         pylint Python-packages/covidcast-py/covidcast/ --rcfile Python-packages/covidcast-py/.pylintrc
+        mypy Python-packages/covidcast-py/covidcast --ignore-missing-imports
     - name: Test with pytest
       run: |
         pytest Python-packages/covidcast-py/

--- a/Python-packages/covidcast-py/covidcast/covidcast.py
+++ b/Python-packages/covidcast-py/covidcast/covidcast.py
@@ -252,7 +252,7 @@ def _fetch_single_geo(data_source: str,  # pylint: disable=W0621
                       geo_value: str,
                       as_of: date,
                       issues: Union[date, tuple, list],
-                      lag: int):
+                      lag: int) -> Union[pd.DataFrame, None]:
     """Fetch data for a single geo.
 
     signal() wraps this to support fetching data over an iterable of

--- a/Python-packages/covidcast-py/covidcast/covidcast.py
+++ b/Python-packages/covidcast-py/covidcast/covidcast.py
@@ -303,7 +303,9 @@ def _fetch_single_geo(data_source: str,  # pylint: disable=W0621
     return None
 
 
-def _signal_metadata(data_source, signal, geo_type) -> dict:  # pylint: disable=W0621
+def _signal_metadata(data_source: str,
+                     signal: str,
+                     geo_type: str) -> dict:  # pylint: disable=W0621
     """Fetch metadata for a single signal as a dict."""
 
     meta = metadata()

--- a/Python-packages/covidcast-py/covidcast/covidcast.py
+++ b/Python-packages/covidcast-py/covidcast/covidcast.py
@@ -9,8 +9,8 @@ from delphi_epidata import Epidata
 VALID_GEO_TYPES = {"county", "hrr", "msa", "dma", "state"}
 
 
-def signal(data_source: str,  # pylint: disable=W0621
-           signal: str,
+def signal(data_source: str,
+           signal: str,  # pylint: disable=W0621
            start_day: date = None,
            end_day: date = None,
            geo_type: str = "county",
@@ -244,8 +244,8 @@ def metadata() -> pd.DataFrame:
     return meta_df
 
 
-def _fetch_single_geo(data_source: str,  # pylint: disable=W0621
-                      signal: str,
+def _fetch_single_geo(data_source: str,
+                      signal: str,  # pylint: disable=W0621
                       start_day: date,
                       end_day: date,
                       geo_type: str,
@@ -304,8 +304,8 @@ def _fetch_single_geo(data_source: str,  # pylint: disable=W0621
 
 
 def _signal_metadata(data_source: str,
-                     signal: str,
-                     geo_type: str) -> dict:  # pylint: disable=W0621
+                     signal: str,  # pylint: disable=W0621
+                     geo_type: str) -> dict:
     """Fetch metadata for a single signal as a dict."""
 
     meta = metadata()
@@ -330,7 +330,7 @@ def _signal_metadata(data_source: str,
     return matches.to_dict("records")[0]
 
 
-def _date_to_api_string(date: date) -> str:
+def _date_to_api_string(date: date) -> str:  # pylint: disable=W0621
     """Convert a date object to a YYYYMMDD string expected by the API."""
 
     return date.strftime("%Y%m%d")

--- a/Python-packages/covidcast-py/covidcast/covidcast.py
+++ b/Python-packages/covidcast-py/covidcast/covidcast.py
@@ -1,6 +1,7 @@
 """This is the client side library for accessing the COVIDcast API."""
 import warnings
-from datetime import timedelta
+from datetime import timedelta, date
+from typing import Union, Iterable, Tuple, List
 
 import pandas as pd
 from delphi_epidata import Epidata
@@ -8,8 +9,15 @@ from delphi_epidata import Epidata
 VALID_GEO_TYPES = {"county", "hrr", "msa", "dma", "state"}
 
 
-def signal(data_source, signal, start_day=None, end_day=None, geo_type="county",  # pylint: disable=W0621
-           geo_values="*", as_of=None, issues=None, lag=None):
+def signal(data_source: str,  # pylint: disable=W0621
+           signal: str,
+           start_day: date = None,
+           end_day: date = None,
+           geo_type: str = "county",
+           geo_values: Iterable[str] = "*",
+           as_of: date = None,
+           issues: Union[date, Tuple[date], List[date]] = None,
+           lag: int = None) -> Union[pd.DataFrame, None]:
     """Download a Pandas data frame for one signal.
 
     Obtains data for selected date ranges for all geographic regions of the
@@ -155,7 +163,7 @@ def signal(data_source, signal, start_day=None, end_day=None, geo_type="county",
     dfs = [
         _fetch_single_geo(
             data_source, signal, start_day, end_day, geo_type, geo_value,
-            as_of, issues, lag)
+            as_of, issues, lag)  # type: ignore
         for geo_value in geo_values
     ]
 
@@ -170,7 +178,7 @@ def signal(data_source, signal, start_day=None, end_day=None, geo_type="county",
     return out
 
 
-def metadata():
+def metadata() -> pd.DataFrame:
     """Fetch COVIDcast surveillance stream metadata.
 
     Obtains a data frame of metadata describing all publicly available data
@@ -236,8 +244,15 @@ def metadata():
     return meta_df
 
 
-def _fetch_single_geo(data_source, signal, start_day, end_day, geo_type,  # pylint: disable=W0621
-                      geo_value, as_of, issues, lag):
+def _fetch_single_geo(data_source: str,  # pylint: disable=W0621
+                      signal: str,
+                      start_day: date,
+                      end_day: date,
+                      geo_type: str,
+                      geo_value: str,
+                      as_of: date,
+                      issues: Union[date, tuple, list],
+                      lag: int):
     """Fetch data for a single geo.
 
     signal() wraps this to support fetching data over an iterable of
@@ -288,7 +303,7 @@ def _fetch_single_geo(data_source, signal, start_day, end_day, geo_type,  # pyli
     return None
 
 
-def _signal_metadata(data_source, signal, geo_type):  # pylint: disable=W0621
+def _signal_metadata(data_source, signal, geo_type) -> dict:  # pylint: disable=W0621
     """Fetch metadata for a single signal as a dict."""
 
     meta = metadata()
@@ -313,13 +328,13 @@ def _signal_metadata(data_source, signal, geo_type):  # pylint: disable=W0621
     return matches.to_dict("records")[0]
 
 
-def _date_to_api_string(date):
+def _date_to_api_string(date: date) -> str:
     """Convert a date object to a YYYYMMDD string expected by the API."""
 
     return date.strftime("%Y%m%d")
 
 
-def _dates_to_api_strings(dates):
+def _dates_to_api_strings(dates: Union[date, list, tuple]) -> str:
     """Convert a date object, or pair of (start, end) objects, to YYYYMMDD strings."""
 
     if not isinstance(dates, (list, tuple)):

--- a/Python-packages/covidcast-py/covidcast/covidcast.py
+++ b/Python-packages/covidcast-py/covidcast/covidcast.py
@@ -14,7 +14,7 @@ def signal(data_source: str,
            start_day: date = None,
            end_day: date = None,
            geo_type: str = "county",
-           geo_values: Iterable[str] = "*",
+           geo_values: Union[str, Iterable[str]] = "*",
            as_of: date = None,
            issues: Union[date, Tuple[date], List[date]] = None,
            lag: int = None) -> Union[pd.DataFrame, None]:

--- a/Python-packages/covidcast-py/requirements.txt
+++ b/Python-packages/covidcast-py/requirements.txt
@@ -2,3 +2,4 @@ pylint
 pytest
 delphi_epidata
 pandas
+mypy

--- a/Python-packages/covidcast-py/tests/covidcast/test_covidcast.py
+++ b/Python-packages/covidcast-py/tests/covidcast/test_covidcast.py
@@ -7,7 +7,7 @@ from covidcast import covidcast
 
 
 def sort_df(df):
-    # helper function for sorting dfs for comparison
+    """Helper function for sorting dfs for comparison."""
     df = df.sort_index(axis=1)
     df.sort_values(df.columns[0], inplace=True)
     return df

--- a/Python-packages/covidcast-py/tests/covidcast/test_covidcast.py
+++ b/Python-packages/covidcast-py/tests/covidcast/test_covidcast.py
@@ -7,7 +7,7 @@ from covidcast import covidcast
 
 
 def sort_df(df):
-    """Helper function for sorting dfs for comparison."""
+    # helper function for sorting dfs for comparison
     df = df.sort_index(axis=1)
     df.sort_values(df.columns[0], inplace=True)
     return df


### PR DESCRIPTION
Summary of changes
1. Add type annotations to covidcast functions. 
2. Update CI to 3.6

Relatively low pri PR here, and open to discussing whether or not it's actually worth adding. I personally find type annotations helpful. Note that these annotations are not enforced at runtime by Python, and are purely for documentation and are often integrated into IDEs. I'm also running a type checker (mypy) on it as part of the CI, which can be slightly annoying and potentially not worth it - we can see how it goes and disable if needed.




A related discussion is if it's worth spending time standardizing some of the argument types to simplify code. I don't know enough about the end user, use case, likelihood of breaking existing user flows, and overall prioritization to make any judgments, but for example, seems like if an argument is 
```
geo_values: Union[str, Iterable[str]] = "*"
```
 and later it's standardized to a list if the input is a string
```
    if isinstance(geo_values, str):
        # User only provided one, not a list
        geo_values = [geo_values]
```
we might want to consider just having a list (and/or other iterable) as the only option for arguments, even if it's one input value.

