### PR TITLE
1. Add join_type to geoDF joining functions. 

### DIFF
--- a/Python-packages/covidcast-py/covidcast/plotting.py
+++ b/Python-packages/covidcast-py/covidcast/plotting.py
@@ -81,7 +81,7 @@ def _join_state_geo_df(data: pd.DataFrame,
     geo_info.STUSPS = [i.lower() for i in geo_info.STUSPS]  # lowercase for consistency
     merged = data.merge(geo_info, how=join_type, left_on=state_col, right_on="STUSPS",)
     # use full state list in the return
-    merged[state_col] = merged.STUSPS
+    merged[state_col] = [j if pd.isna(i) else i for i, j in zip(merged.STUSPS, merged[state_col])]
     return merged
 
 
@@ -109,5 +109,5 @@ def _join_county_geo_df(data: pd.DataFrame,
         merged = merged.merge(mega_county_df, how="left", left_on="STATEFP", right_on="state")
         merged["value"] = [j if pd.isna(i) else i for i, j in zip(merged.value_x, merged.value_y)]
     # use the full county FIPS list in the return
-    merged[county_col] = merged.GEOID
+    merged[county_col] = [j if pd.isna(i) else i for i, j in zip(merged.GEOID, merged[county_col])]
     return merged

--- a/Python-packages/covidcast-py/covidcast/plotting.py
+++ b/Python-packages/covidcast-py/covidcast/plotting.py
@@ -17,7 +17,8 @@ SHAPEFILE_PATHS = {"county": "shapefiles/cb_2019_us_county_5m.zip",
 
 def get_geo_df(data: pd.DataFrame,
                geo_value_col: str = "geo_value",
-               geo_type_col: str = "geo_type") -> gpd.GeoDataFrame:
+               geo_type_col: str = "geo_type",
+               join_type: str = "right") -> gpd.GeoDataFrame:
     """Append polygons to a dataframe for a given geography and return a geoDF with this info.
 
     This method takes in a pandas DataFrame object and returns a GeoDataFrame object from the
@@ -25,9 +26,15 @@ def get_geo_df(data: pd.DataFrame,
 
     After detecting the geography type (either county or state) for the input, loads the
     GeoDataFrame which contains state and geometry information from the Census for that geography
-    type. Left joins the input data to this, so all states/counties will always be present
-    regardless of the input i.e. the output dimension for a given geo_type is always the same
-    regardless of input. Finally, returns the columns containing the input columns along with a
+    type. By default, it will take the input data (left side) and geo data (right side) and right
+    join them, so all states/counties will always be present regardless of the input i.e. the
+    output dimension for a given geo_type is always the same regardless of input.
+    `left`, `outer`, `inner` joins are also supported.
+
+    For right joins on counties, all counties without a signal value will be given the value of
+    the megacounty (if present). Other joins will not use megacounties.
+
+    Returns the columns containing the input columns along with a
     `geometry` (polygon for plotting) and `state_fips` (FIPS code which will be used in the
     plotting function to rearrange AK and HI) column. Coordinate system is GCS NAD83.
 
@@ -37,35 +44,42 @@ def get_geo_df(data: pd.DataFrame,
     :param data: DataFrame of values and geographies
     :param geo_value_col: name of column containing values of interest
     :param geo_type_col: name of column containing geography type
+    :param join_type: Type of join to do between input data (left side) and geo data (right side). \
+    must be one of `right`(default), `left`, `outer`, `inner`
     :return: GeoDataFrame of all state and geometry info for given geo type w/ input data appended.
     """
+    if join_type == "right" and any(data[geo_value_col].duplicated()):
+        raise ValueError("join_type `right` is incompatible with duplicate values in a "
+                         "given region. Use `left` or ensure your input data is a single signal for"
+                         "a single date and geography type. ")
     geo_type = _detect_metadata(data, geo_type_col)[2]  # pylint: disable=W0212
-    output_cols = list(data.columns) + ["geometry", "state_fips"]
+    if geo_type not in ["state", "county"]:
+        raise ValueError("Unsupported geography type; only state and county supported.")
 
+    output_cols = list(data.columns) + ["geometry", "state_fips"]
     shapefile_path = pkg_resources.resource_filename(__name__, SHAPEFILE_PATHS[geo_type])
     geo_info = gpd.read_file("zip://" + shapefile_path)
 
     if geo_type == "state":
-        output = _join_state_geo_df(data, geo_value_col, geo_info)
-    elif geo_type == "county":
-        output = _join_county_geo_df(data, geo_value_col, geo_info)
-    else:
-        raise ValueError("Unsupported geography type; only state and county supported.")
+        output = _join_state_geo_df(data, geo_value_col, geo_info, join_type)
+    else:  # geo_type must be "county"
+        output = _join_county_geo_df(data, geo_value_col, geo_info, join_type)
     output.rename(columns={"STATEFP": "state_fips"}, inplace=True)
     return output[output_cols]
 
 
 def _join_state_geo_df(data: pd.DataFrame,
                        state_col: str,
-                       geo_info: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
-    """Left join DF information to polygon information in a GeoDF at the state level.
+                       geo_info: gpd.GeoDataFrame,
+                       join_type: str = "right") -> gpd.GeoDataFrame:
+    """Join DF information to polygon information in a GeoDF at the state level.
 
     :param data: DF with state info
     :param state_col: cname of column in `data` containing state info to join on
     :param geo_info: GeoDF of state shape info read from Census shapefiles
     """
     geo_info.STUSPS = [i.lower() for i in geo_info.STUSPS]  # lowercase for consistency
-    merged = geo_info.merge(data, how="left", left_on="STUSPS", right_on=state_col)
+    merged = data.merge(geo_info, how=join_type, left_on=state_col, right_on="STUSPS",)
     # use full state list in the return
     merged[state_col] = merged.STUSPS
     return merged
@@ -73,8 +87,10 @@ def _join_state_geo_df(data: pd.DataFrame,
 
 def _join_county_geo_df(data: pd.DataFrame,
                         county_col: str,
-                        geo_info: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
-    """Left join DF information to polygon information in a GeoDF at the county level.
+                        geo_info: gpd.GeoDataFrame,
+                        join_type: str = "right"
+                        ) -> gpd.GeoDataFrame:
+    """Join DF information to polygon information in a GeoDF at the county level.
 
     Counties with no direct key in the data DF will have the megacounty value joined.
 
@@ -85,10 +101,10 @@ def _join_county_geo_df(data: pd.DataFrame,
     # create state FIPS code in copy, otherwise original gets modified
     data = data.assign(state=[i[:2] for i in data[county_col]])
     # join all counties with valid FIPS
-    merged = geo_info.merge(data, how="left", left_on="GEOID", right_on=county_col)
-    mega_county_df = data.loc[[i.endswith('000') for i in data[county_col]],
+    merged = data.merge(geo_info, how=join_type, left_on=county_col, right_on="GEOID")
+    mega_county_df = data.loc[[i.endswith("000") for i in data[county_col]],
                               ["state", "value"]]
-    if not mega_county_df.empty:
+    if not mega_county_df.empty and join_type == "right":
         # if mega counties exist, join them on state, and then use that value if no original signal
         merged = merged.merge(mega_county_df, how="left", left_on="STATEFP", right_on="state")
         merged["value"] = [j if pd.isna(i) else i for i, j in zip(merged.value_x, merged.value_y)]

--- a/Python-packages/covidcast-py/covidcast/plotting.py
+++ b/Python-packages/covidcast-py/covidcast/plotting.py
@@ -44,8 +44,8 @@ def get_geo_df(data: pd.DataFrame,
     :param data: DataFrame of values and geographies
     :param geo_value_col: name of column containing values of interest
     :param geo_type_col: name of column containing geography type
-    :param join_type: Type of join to do between input data (left side) and geo data (right side). \
-    must be one of `right`(default), `left`, `outer`, `inner`
+    :param join_type: Type of join to do between input data (left side) and geo data (right side).
+      must be one of `right`(default), `left`, `outer`, `inner`
     :return: GeoDataFrame of all state and geometry info for given geo type w/ input data appended.
     """
     if join_type == "right" and any(data[geo_value_col].duplicated()):

--- a/Python-packages/covidcast-py/tests/covidcast/test_plotting.py
+++ b/Python-packages/covidcast-py/tests/covidcast/test_plotting.py
@@ -21,10 +21,12 @@ def test_get_geo_df():
     output = plotting.get_geo_df(test_input)
     assert output.shape == (3233, test_input.shape[1]+2)
     assert not any(pd.isna(output.geometry))
+    assert not any(pd.isna(output.geo_value))  # all geo_values should be populated
 
     # test counties w/ right join
     output = plotting.get_geo_df(test_input, join_type="left")
     assert output.shape == (3, test_input.shape[1]+2)
+    assert not any(pd.isna(output.geo_value))
     assert sum(pd.isna(output.geometry)) == 1  # one megacounty should be nan
 
     # test states
@@ -32,6 +34,7 @@ def test_get_geo_df():
     output = plotting.get_geo_df(test_input)
     assert output.shape == (56, test_input.shape[1]+2)
     assert not any(pd.isna(output.geometry))
+    assert not any(pd.isna(output.geo_value))
 
     # just test output cols match, since the actual values are tested in the _join_*_geo_df methods
     assert set(output.columns) == {"geo_value", "value", "geo_type", "signal",


### PR DESCRIPTION
Summary of changes:
- Add a join_type argument to the `get_geo_df` function and the helper methods it uses.

The original implementation was that given a single day/signal/geo, the full GeoDF provided by the census would have the values joined in (so the output DF is the same dimensions). The problem is that someone can't choose append polgyons to their DF without this behaviour (e.g. they have 10 days of signals for a five specific counties and just want polygons inner joined to those), and if they have multiple values for the same geographies, the output starts being weird since it's no longer "Here's one row per region with it's respective value". Now, the user can just decide how they want the data joined. The original implementation is still default and will require a distinct series of regions so there are no duplicates cases. A user could also pass in `inner` or another join if they wanted something specific.

An alternative solution would be to make `get_geo_df` take in arguments for a specific date/source/signal/geo_type (i.e. whatever uniquely defines a set of geographies and values) so it can always slice out the right input, but the downside is that the user still lacks the flexibility of the original implementation.

One thing is that I'm not intending this function for use cases where someone is looping through multiple individual rows and then having geo information returned .e.g `[get_geo_df(i) for i in ...]`, since i) `get_geo_df` loads the GeoDF every time and ii) pandas join seems like overkill for this. I'm going (potentially naively) to assume that anyone doing that sort of thing probably could just load the geo info into a dict themselves and run `[geo_dict.get(i, None) for i in...]`, but if that's not a good assumption we can discuss implementing a class that can do it (could extend a similar interface for most of the geomapping stuff @jsharpna  is doing) 


