### PR TITLE
Point both packages to the AWS API endpoint

### DIFF
--- a/Python-packages/covidcast-py/covidcast/covidcast.py
+++ b/Python-packages/covidcast-py/covidcast/covidcast.py
@@ -6,6 +6,9 @@ from typing import Union, Iterable, Tuple, List
 import pandas as pd
 from delphi_epidata import Epidata
 
+# Point API requests to the AWS endpoint
+Epidata.BASE_URL = "https://api.covidcast.cmu.edu/epidata/api.php"
+
 VALID_GEO_TYPES = {"county", "hrr", "msa", "dma", "state"}
 
 

--- a/R-packages/covidcast/R/covidcast.R
+++ b/R-packages/covidcast/R/covidcast.R
@@ -1,5 +1,5 @@
 # API base url
-COVIDCAST_BASE_URL <- 'https://delphi.cmu.edu/epidata/api.php'
+COVIDCAST_BASE_URL <- 'https://api.covidcast.cmu.edu/epidata/api.php'
 
 .onAttach <- function(libname, pkgname) {
   msg <- c("We encourage COVIDcast API users to register on our mailing list:",


### PR DESCRIPTION
In preparation for higher traffic loads, point to the AWS read-only
replicas.