### PR TITLE
Further improve Python client docs

### DIFF
--- a/Python-packages/covidcast-py/covidcast/covidcast.py
+++ b/Python-packages/covidcast-py/covidcast/covidcast.py
@@ -70,9 +70,9 @@ def signal(data_source: str,
     :param start_day: Query data beginning on this date. Provided as a
       ``datetime.date`` object. If ``start_day`` is ``None``, defaults to the
       first day data is available for this signal.
-    :param end_day: Query data up to this date, inclusive. ``datetime.date``
-      object. If ``end_day`` is ``None``, defaults to the most recent day data
-      is available for this signal.
+    :param end_day: Query data up to this date, inclusive. Provided as a
+      ``datetime.date`` object. If ``end_day`` is ``None``, defaults to the most
+      recent day data is available for this signal.
     :param geo_type: The geography type for which to request this data, such as
       ``"county"`` or ``"state"``. Available types are described in the
       COVIDcast signal documentation. Defaults to ``"county"``.
@@ -100,7 +100,10 @@ def signal(data_source: str,
       columns:
 
       ``geo_value``
-        identifies the location, such as a state name or county FIPS code.
+        identifies the location, such as a state name or county FIPS code. The
+        geographic coding used by COVIDcast is described in the `API
+        documentation here
+        <https://cmu-delphi.github.io/delphi-epidata/api/covidcast_geography.html>`_.
 
       ``time_value``
         contains a `pandas Timestamp object
@@ -137,8 +140,10 @@ def signal(data_source: str,
         currently increasing or decreasing (reported as -1 for decreasing, 1 for
         increasing, and 0 for neither).
 
-    Consult the signal documentation for more details on how values and standard
-    errors are calculated for specific signals.
+    Consult the `signal documentation
+    <https://cmu-delphi.github.io/delphi-epidata/api/covidcast_signals.html>`_
+    for more details on how values and standard errors are calculated for
+    specific signals.
 
     """
 
@@ -190,47 +195,48 @@ def metadata() -> pd.DataFrame:
     <https://cmu-delphi.github.io/delphi-epidata/api/covidcast_signals.html>`_
     for descriptions of the available sources.
 
-    The returned data frame contains one row per available signal, with the
-    following columns:
+    :returns: A data frame containing one row per available signal, with the
+      following columns:
 
-    ``data_source``
+      ``data_source``
         Data source name.
 
-    ``signal``
+      ``signal``
         Signal name.
 
-    ``min_time``
+      ``min_time``
         First day for which this signal is available.
 
-    ``max_time``
+      ``max_time``
         Most recent day for which this signal is available.
 
-    ``geo_type``
+      ``geo_type``
         Geographic level for which this signal is available, such as county,
         state, msa, or hrr. Most signals are available at multiple geographic
         levels and will hence be listed in multiple rows with their own
         metadata.
 
-    ``time_type``
+      ``time_type``
         Temporal resolution at which this signal is reported. "day", for
         example, means the signal is reported daily.
 
-    ``num_locations``
+      ``num_locations``
         Number of distinct geographic locations available for this signal. For
         example, if `geo_type` is county, the number of counties for which this
         signal has ever been reported.
 
-    ``min_value``
+      ``min_value``
         The smallest value that has ever been reported.
 
-    ``max_value``
+      ``max_value``
         The largest value that has ever been reported.
 
-    ``mean_value``
+      ``mean_value``
         The arithmetic mean of all reported values.
 
-    ``stdev_value``
+      ``stdev_value``
         The sample standard deviation of all reported values.
+
     """
 
     meta = Epidata.covidcast_meta()

--- a/Python-packages/covidcast-py/covidcast/plotting.py
+++ b/Python-packages/covidcast-py/covidcast/plotting.py
@@ -81,21 +81,20 @@ def get_geo_df(data: pd.DataFrame,
                join_type: str = "right") -> gpd.GeoDataFrame:
     """Augment a :py:func:`covidcast.signal` data frame with the shape of each geography.
 
-    This method takes in a pandas DataFrame object and returns a GeoDataFrame object from the
-    `GeoPandas package <https://geopandas.org/>`_.
-
-    Shapefiles are 1:5,000,000 scale and sourced from the `2019 US Census Cartographic Boundary
-    Files
-    <https://www.census.gov/geographies/mapping-files/time-series/geo/cartographic-boundary.html>`_.
+    This method takes in a pandas DataFrame object and returns a GeoDataFrame
+    object from the `GeoPandas package <https://geopandas.org/>`_. The
+    GeoDataFrame will contain the geographic shape corresponding to every row in
+    its ``geometry`` colummn; for example, a data frame of county-level signal
+    observations will be returned with the shape of every county.
 
     After detecting the geography type (only county and state are currently
-    supported) of the input, builds a GeoDataFrame that contains state and
-    geometry information from the Census for that geography type. By default, it
-    will take the signal data (left side) and geo data (right side) and right
-    join them, so all states/counties will always be present regardless whether
-    ``data`` contains values for those locations. ``left``, ``outer``, and
-    ``inner`` joins are also supported and can be selected with the
-    ``join_type`` argument.
+    supported) of the input, this function builds a GeoDataFrame that contains
+    state and geometry information from the Census for that geography type. By
+    default, it will take the signal data (left side) and geo data (right side)
+    and right join them, so all states/counties will always be present
+    regardless whether ``data`` contains values for those locations. ``left``,
+    ``outer``, and ``inner`` joins are also supported and can be selected with
+    the ``join_type`` argument.
 
     For right joins on counties, all counties without a signal value will be
     given the value of the megacounty (if present). Other joins will not use
@@ -103,8 +102,15 @@ def get_geo_df(data: pd.DataFrame,
     <https://cmu-delphi.github.io/delphi-epidata/api/covidcast_geography.html>`_
     for information about megacounties.
 
-    Default arguments for column names correspond to those used by
-    :py:func:`covidcast.signal`. Currently only supports counties and states.
+    By default, this function identifies the geography for each row of the input
+    data frame using its ``geo_value`` column, matching data frames returned by
+    :py:func:`covidcast.signal`, but the ``geo_value_col`` and ``geo_type_col``
+    arguments can be provided to match geographies for data frames with
+    different column names.
+
+    Geographic data is sourced from 1:5,000,000-scale shapefiles from the `2019
+    US Census Cartographic Boundary Files
+    <https://www.census.gov/geographies/mapping-files/time-series/geo/cartographic-boundary.html>`_.
 
     :param data: DataFrame of values and geographies
     :param geo_value_col: name of column containing values of interest
@@ -115,6 +121,7 @@ def get_geo_df(data: pd.DataFrame,
       with a ``geometry`` column (containing a polygon) and a ``state_fips``
       column (a two-digit FIPS code identifying the US state containing this
       geography). The geometry is given in the GCS NAD83 coordinate system.
+
     """
 
     if join_type == "right" and any(data[geo_value_col].duplicated()):

--- a/Python-packages/covidcast-py/covidcast/plotting.py
+++ b/Python-packages/covidcast-py/covidcast/plotting.py
@@ -36,7 +36,7 @@ def plot_choropleth(data: pd.DataFrame,
     <https://matplotlib.org/tutorials/colors/colormaps.html>`_ used is
     ``YlOrRd`` and is binned into the signal's historical mean value ± 3
     standard deviations. Custom arguments can be passed in as ``kwargs`` for
-    customizability. These arguments will be past to the GeoPandas ``plot``
+    customizability. These arguments will be passed to the GeoPandas ``plot``
     method; more information on these arguments can be found in `the GeoPandas
     documentation
     <https://geopandas.org/reference.html#geopandas.GeoDataFrame.plot>`_.
@@ -92,7 +92,7 @@ def get_geo_df(data: pd.DataFrame,
     state and geometry information from the Census for that geography type. By
     default, it will take the signal data (left side) and geo data (right side)
     and right join them, so all states/counties will always be present
-    regardless whether ``data`` contains values for those locations. ``left``,
+    regardless of whether ``data`` contains values for those locations. ``left``,
     ``outer``, and ``inner`` joins are also supported and can be selected with
     the ``join_type`` argument.
 
@@ -112,9 +112,9 @@ def get_geo_df(data: pd.DataFrame,
     US Census Cartographic Boundary Files
     <https://www.census.gov/geographies/mapping-files/time-series/geo/cartographic-boundary.html>`_.
 
-    :param data: DataFrame of values and geographies
-    :param geo_value_col: name of column containing values of interest
-    :param geo_type_col: name of column containing geography type
+    :param data: DataFrame of values and geographies.
+    :param geo_value_col: Name of column containing values of interest.
+    :param geo_type_col: Name of column containing geography type.
     :param join_type: Type of join to do between input data (left side) and geo data (right side).
       Must be one of `right` (default), `left`, `outer`, or `inner`.
     :return: GeoDataFrame containing all columns from the input ``data``, along

--- a/Python-packages/covidcast-py/covidcast/plotting.py
+++ b/Python-packages/covidcast-py/covidcast/plotting.py
@@ -8,6 +8,7 @@ import numpy as np
 import pandas as pd
 import pkg_resources
 from matplotlib import pyplot as plt
+import matplotlib.figure
 
 from .covidcast import _detect_metadata, _signal_metadata
 
@@ -17,7 +18,7 @@ SHAPEFILE_PATHS = {"county": "shapefiles/county/cb_2019_us_county_5m.shp",
 
 def plot_choropleth(data: pd.DataFrame,
                     time_value: date = None,
-                    **kwargs) -> gpd.GeoDataFrame:
+                    **kwargs) -> matplotlib.figure.Figure:
     """Given the output data frame of :py:func:`covidcast.signal`, plot a choropleth map.
 
     Projections used for plotting:
@@ -31,19 +32,23 @@ def plot_choropleth(data: pd.DataFrame,
     For visual purposes, Alaska and Hawaii are moved the lower left corner of the contiguous US
     and Puerto Rico is moved closer to Florida.
 
-    By default, the colormap used is ``YlOrRd`` and is binned into the signal's
-    mean value +- 3 standard deviations. Custom arguments can be passed in as
-    ``kwargs`` for customizability. These arguments will be past to the
-    GeoPandas ``plot`` method; more information on these arguments can be found
-    in `the GeoPandas documentation
-    <https://geopandas.org/reference.html#geopandas.GeoSeries.plot>`__.
+    By default, the `colormap
+    <https://matplotlib.org/tutorials/colors/colormaps.html>`_ used is
+    ``YlOrRd`` and is binned into the signal's historical mean value ± 3
+    standard deviations. Custom arguments can be passed in as ``kwargs`` for
+    customizability. These arguments will be past to the GeoPandas ``plot``
+    method; more information on these arguments can be found in `the GeoPandas
+    documentation
+    <https://geopandas.org/reference.html#geopandas.GeoDataFrame.plot>`_.
 
-    :param data: DataFrame of values and geographies.
-    :param time_value: If multiple days of data are present in ``data``, map only values from this \
-        day. Defaults to plotting the most recent day of data in ``data``.
-    :param kwargs: Optional keyword arguments passed to plot().
+    :param data: Data frame of signal values, as returned from :py:func:`covidcast.signal`.
+    :param time_value: If multiple days of data are present in ``data``, map only values from this
+      day. Defaults to plotting the most recent day of data in ``data``.
+    :param kwargs: Optional keyword arguments passed to ``GeoDataFrame.plot()``.
     :return: Matplotlib figure object.
+
     """
+
     data_source, signal, geo_type = _detect_metadata(data)  # pylint: disable=W0212
     meta = _signal_metadata(data_source, signal, geo_type)  # pylint: disable=W0212
     # use most recent date in data if none provided
@@ -74,39 +79,44 @@ def get_geo_df(data: pd.DataFrame,
                geo_value_col: str = "geo_value",
                geo_type_col: str = "geo_type",
                join_type: str = "right") -> gpd.GeoDataFrame:
-    """Append polygons to a dataframe for a given geography and return a geoDF with this info.
+    """Augment a :py:func:`covidcast.signal` data frame with the shape of each geography.
 
     This method takes in a pandas DataFrame object and returns a GeoDataFrame object from the
-    `GeoPandas package <https://geopandas.org/>`__.
+    `GeoPandas package <https://geopandas.org/>`_.
 
     Shapefiles are 1:5,000,000 scale and sourced from the `2019 US Census Cartographic Boundary
     Files
-    <https://www.census.gov/geographies/mapping-files/time-series/geo/cartographic-boundary.html>`__
+    <https://www.census.gov/geographies/mapping-files/time-series/geo/cartographic-boundary.html>`_.
 
-    After detecting the geography type (either county or state) for the input, loads the
-    GeoDataFrame which contains state and geometry information from the Census for that geography
-    type. By default, it will take the input data (left side) and geo data (right side) and right
-    join them, so all states/counties will always be present regardless whether ``data`` contains
-    values for those locations. ``left``, ``outer``, and ``inner`` joins are also supported and
-    can be selected with the ``join_type`` argument.
+    After detecting the geography type (only county and state are currently
+    supported) of the input, builds a GeoDataFrame that contains state and
+    geometry information from the Census for that geography type. By default, it
+    will take the signal data (left side) and geo data (right side) and right
+    join them, so all states/counties will always be present regardless whether
+    ``data`` contains values for those locations. ``left``, ``outer``, and
+    ``inner`` joins are also supported and can be selected with the
+    ``join_type`` argument.
 
-    For right joins on counties, all counties without a signal value will be given the value of
-    the megacounty (if present). Other joins will not use megacounties.
+    For right joins on counties, all counties without a signal value will be
+    given the value of the megacounty (if present). Other joins will not use
+    megacounties. See the `geographic coding documentation
+    <https://cmu-delphi.github.io/delphi-epidata/api/covidcast_geography.html>`_
+    for information about megacounties.
 
-    Returns the columns from ``data`` along with
-    `geometry` (polygon for plotting) and `state_fips` (FIPS code which will be used in the
-    plotting function to rearrange AK and HI) column. Coordinate system is GCS NAD83.
-
-    Default arguments for column names correspond to those used by :py:func:`covidcast.signal`.
-    Currently only supports counties and states.
+    Default arguments for column names correspond to those used by
+    :py:func:`covidcast.signal`. Currently only supports counties and states.
 
     :param data: DataFrame of values and geographies
     :param geo_value_col: name of column containing values of interest
     :param geo_type_col: name of column containing geography type
     :param join_type: Type of join to do between input data (left side) and geo data (right side).
-      must be one of `right`(default), `left`, `outer`, `inner`
-    :return: GeoDataFrame of all state and geometry info for given geo type w/ input data appended.
+      Must be one of `right` (default), `left`, `outer`, or `inner`.
+    :return: GeoDataFrame containing all columns from the input ``data``, along
+      with a ``geometry`` column (containing a polygon) and a ``state_fips``
+      column (a two-digit FIPS code identifying the US state containing this
+      geography). The geometry is given in the GCS NAD83 coordinate system.
     """
+
     if join_type == "right" and any(data[geo_value_col].duplicated()):
         raise ValueError("join_type `right` is incompatible with duplicate values in a "
                          "given region. Use `left` or ensure your input data is a single signal for"

--- a/Python-packages/covidcast-py/docs/changelog.rst
+++ b/Python-packages/covidcast-py/docs/changelog.rst
@@ -2,7 +2,8 @@ Changelog
 =========
 
 v0.0.9, August 30, 2020
----------------------
+-----------------------
+
 - New feature: :py:func:`covidcast.plot_choropleth` and :py:func:`covidcast.get_geo_df`
   add mapping and plotting capabilities that can be used with the data returned by
   :py:func:`covidcast.signal`. See the :ref:`function documentation <plotting-data>`

--- a/Python-packages/covidcast-py/docs/plotting.rst
+++ b/Python-packages/covidcast-py/docs/plotting.rst
@@ -6,9 +6,10 @@ Plotting Reference
 Choropleth maps
 ---------------
 
-This package provides a plotting function that takes a county or state level signal and
-generates a choropleth map. Detailed examples are provided in the :ref:`usage examples
-<plotting-examples>`.
+This package provides a plotting function that takes a county or state level
+signal and generates a choropleth map, using `matplotlib
+<https://matplotlib.org/>`_ underneath. Detailed examples are provided in the
+:ref:`usage examples <plotting-examples>`.
 
 .. autofunction:: covidcast.plot_choropleth
 


### PR DESCRIPTION
Some further improvement to the Sphinx docs before release.

@chinandrew, a couple questions for your review:

* I noticed that `plot_choropleth` had a type annotation saying it returned a `gpd.GeoDataFrame`, which is false, since we changed it to return the figure object. Is the type annotation checked by any of our tooling? I've never used Python type annotations, so I don't know how mypy fits in here.
* `plot_choropleth` pointed to the GeoSeries `plot` method, but I assume it actually uses the `GeoDataFrame` method, so I switched the links. Did I guess right?