### PR TITLE
Fix time_value bug on Python choropleth

### DIFF
--- a/Python-packages/covidcast-py/covidcast/plotting.py
+++ b/Python-packages/covidcast-py/covidcast/plotting.py
@@ -71,7 +71,7 @@ def plot_choropleth(data: pd.DataFrame,
     meta = _signal_metadata(data_source, signal, geo_type)  # pylint: disable=W0212
     # use most recent date in data if none provided
     day_to_plot = time_value if time_value else max(data.time_value)
-    day_data = data.loc[data.time_value == day_to_plot, :]
+    day_data = data.loc[data.time_value == pd.to_datetime(day_to_plot), :]
     data_w_geo = get_geo_df(day_data)
 
     kwargs["vmin"] = kwargs.get("vmin", 0)

--- a/Python-packages/covidcast-py/tests/covidcast/test_plotting.py
+++ b/Python-packages/covidcast-py/tests/covidcast/test_plotting.py
@@ -18,6 +18,7 @@ NON_GEOMETRY_COLS = ["geo_value", "time_value", "direction", "issue", "lag", "va
 
 
 def test_plot_choropleth():
+    # see PR #72
     test_county = pd.read_csv(
         os.path.join(CURRENT_PATH, "../reference_data/test_input_county_signal.csv"), dtype=str)
     test_county["time_value"] = test_county.time_value.astype("datetime64[D]")

--- a/Python-packages/covidcast-py/tests/covidcast/test_plotting.py
+++ b/Python-packages/covidcast-py/tests/covidcast/test_plotting.py
@@ -1,4 +1,5 @@
 import os
+from datetime import date
 
 import geopandas as gpd
 import numpy as np
@@ -14,6 +15,15 @@ CURRENT_PATH = os.path.dirname(os.path.realpath(__file__))
 
 NON_GEOMETRY_COLS = ["geo_value", "time_value", "direction", "issue", "lag", "value", "stderr",
                      "sample_size", "geo_type", "data_source", "signal", "state_fips"]
+
+
+def test_plot_choropleth():
+    test_county = pd.read_csv(
+        os.path.join(CURRENT_PATH, "../reference_data/test_input_county_signal.csv"), dtype=str)
+    test_county["time_value"] = test_county.time_value.astype("datetime64[D]")
+    test_county["value"] = test_county.value.astype("float")
+    assert plotting.plot_choropleth(test_county, time_value=date(2020, 8, 4))
+    assert plotting.plot_choropleth(test_county)
 
 
 def test_get_geo_df():


### PR DESCRIPTION
Turns out 
```
data.loc[data.time_value == day_to_plot, :]
```
doesn't work because `day_to_plot` is a datetime.date object and the dataframe column is a pandas timestamp object, so instead we need to be doing this

```
data.loc[data.time_value == pd.to_datetime(day_to_plot), :]
```

Otherwise an empty dataframe gets returned and the function errors downstream. Added a basic test that just runs the function and will fail if it errors.

Guess it was a case that was never manually tested and we didn't have tests around plotting :(.