### PR TITLE
Change colorbar size and round decimals

### DIFF
--- a/Python-packages/covidcast-py/covidcast/plotting.py
+++ b/Python-packages/covidcast-py/covidcast/plotting.py
@@ -96,7 +96,7 @@ def plot_choropleth(data: pd.DataFrame,
     for shape in _project_and_transform(data_w_geo):
         shape.plot("value", ax=ax, **kwargs)
     plt.colorbar(sm, ticks=np.linspace(kwargs["vmin"], kwargs["vmax"], 8), ax=ax,
-                 orientation="horizontal", fraction=0.02, pad=0.05)
+                 orientation="horizontal", fraction=0.045, pad=0.04, format="%.2f")
     return fig
 
 


### PR DESCRIPTION
Fixes #75.

Summary of changes:
- Adjust colorbar size so it works on smaller plots and round decimals to 2 digits.

default size (12.8, 9.6)
![Screenshot from 2020-09-13 12-13-57](https://user-images.githubusercontent.com/20176218/93026440-cec59980-f5ba-11ea-8859-8d71e2ec28ca.png)

(6,4)
![Screenshot from 2020-09-13 12-13-42](https://user-images.githubusercontent.com/20176218/93026441-cff6c680-f5ba-11ea-992a-67a5e6755934.png)
