### PR TITLE
Add source overview to documentation

### DIFF
--- a/Python-packages/covidcast-py/docs/getting_started.rst
+++ b/Python-packages/covidcast-py/docs/getting_started.rst
@@ -29,8 +29,6 @@ your favorite Python package manager:
    pip install covidcast
 
 
-.. _signal-overview:
-
 Signal Overview
 ---------------
 The `Delphi Epidata documentation
@@ -69,7 +67,6 @@ the source would be ``ght`` and the signal would be ``raw_search``, as shown on 
 `page for that signal <https://cmu-delphi.github.io/delphi-epidata/api/covidcast-signals/ght.html>`_.
 These values will be provided as the arguments for the :py:func:`covidcast.signal` function to
 retrieve the desired data.
-
 
 
 Basic examples

--- a/Python-packages/covidcast-py/docs/getting_started.rst
+++ b/Python-packages/covidcast-py/docs/getting_started.rst
@@ -28,6 +28,7 @@ your favorite Python package manager:
 
    pip install covidcast
 
+This will install the package as well as all required dependencies.
 
 Signal Overview
 ---------------
@@ -64,7 +65,8 @@ To specify a signal, you will need the "Source Name" and "Signal" value, which a
 listed for each source/signal combination on their respective page.
 For example, to obtain the raw Google search volume for COVID-related topics,
 the source would be ``ght`` and the signal would be ``raw_search``, as shown on the
-`page for that signal <https://cmu-delphi.github.io/delphi-epidata/api/covidcast-signals/ght.html>`_.
+`Google Health Trends page
+<https://cmu-delphi.github.io/delphi-epidata/api/covidcast-signals/ght.html>`_.
 These values will be provided as the arguments for the :py:func:`covidcast.signal` function to
 retrieve the desired data.
 

--- a/Python-packages/covidcast-py/docs/getting_started.rst
+++ b/Python-packages/covidcast-py/docs/getting_started.rst
@@ -14,7 +14,7 @@ live from the server when you make a request, and is not stored within the packa
 itself. This means that each time you make a request, you will be receiving the latest
 data. If you are conducting an analysis or powering a service which will require
 repeated access to the same signal, please download the data rather than making repeated
-requests. For more information on data latency and refreshes, see :ref:`obtaining-signals`
+requests.
 
 
 Installation
@@ -63,7 +63,7 @@ a brief overview of each source, with links to their full descriptions.
     - Confirmed COVID cases and deaths based on reports made available by USAFacts.
 
 To specify a signal, you will need the "Source Name" and "Signal" value, which are
-listed for each source/signal combination in their full description.
+listed for each source/signal combination on their respective page.
 For example, to obtain the raw Google search volume for COVID-related topics,
 the source would be ``ght`` and the signal would be ``raw_search``, as shown on the
 `page for that signal <https://cmu-delphi.github.io/delphi-epidata/api/covidcast-signals/ght.html>`_.

--- a/Python-packages/covidcast-py/docs/getting_started.rst
+++ b/Python-packages/covidcast-py/docs/getting_started.rst
@@ -3,19 +3,74 @@
 Getting Started
 ===============
 
+
+Overview
+------------
+
 This package provides access to data from the `COVIDcast API
 <https://cmu-delphi.github.io/delphi-epidata/api/covidcast.html>`_, which
-provides numerous COVID-related data streams, updated daily. To begin, you'll
-want to browse the available data streams and determine which signals are useful
-to you. The `COVIDcast interactive map <https://covidcast.cmu.edu/>`_ displays a
-selection of the signals, and by selecting the Export Data feature, you can get
-example Python code to access each of the signals.
+provides numerous COVID-related data streams, updated daily. The data is retrieved
+live from the server when you make a request, and is not stored within the package
+itself. This means that each time you make a request, you will be receiving the latest
+data. If you are conducting an analysis or powering a service which will require
+repeated access to the same signal, please download the data rather than making repeated
+requests. For more information on data latency and refreshes, see :ref:`obtaining-signals`
 
-To browse in more detail, the `data sources and signal documentation
+
+Installation
+------------
+
+This package is available on PyPI as `covidcast
+<https://pypi.org/project/covidcast/>`_, and can be installed using ``pip`` or
+your favorite Python package manager:
+
+.. code-block:: sh
+
+   pip install covidcast
+
+
+.. _signal-overview:
+
+Signal Overview
+---------------
+The `Delphi Epidata documentation
 <https://cmu-delphi.github.io/delphi-epidata/api/covidcast_signals.html>`_ lists
-the available signals, including many not shown on the interactive map. Simply
-obtain the data source and signal names from the list. Below we will demonstrate
-how to use these names to access each data stream.
+the available signals, including many not shown on the
+`COVIDcast interactive map
+<https://covidcast.cmu.edu/>`_.
+
+The data come from a variety of sources and cover information including official case counts,
+internet search trends, hospital encounters, testing volume, survey responses, and more. Below is
+a brief overview of each source, with links to their full descriptions.
+
+- `Doctor Visits <https://cmu-delphi.github.io/delphi-epidata/api/covidcast-signals/doctor-visits.html>`_
+    - Outpatient visits with COVID-related symptoms.
+- `Google Health Trends <https://cmu-delphi.github.io/delphi-epidata/api/covidcast-signals/ght.html>`_
+    - COVID-related Google search volume.
+- `Hospital Admissions <https://cmu-delphi.github.io/delphi-epidata/api/covidcast-signals/hospital-admissions.html>`_
+    - Hospital admissions with COVID-associated diagnoses.
+- `Indicator Combination <https://cmu-delphi.github.io/delphi-epidata/api/covidcast-signals/indicator-combination.html>`_
+    - Aggregated signal of other sources to provide a single COVID activity indicator.
+- `JHU Cases and Deaths <https://cmu-delphi.github.io/delphi-epidata/api/covidcast-signals/jhu-csse.html>`_
+    - Confirmed COVID cases and deaths based on reports made available by Johns Hopkins University.
+- `Quidel <https://cmu-delphi.github.io/delphi-epidata/api/covidcast-signals/quidel.html>`_
+    - Positive COVID antigen tests.
+- `SafeGraph Mobility <https://cmu-delphi.github.io/delphi-epidata/api/covidcast-signals/safegraph.html>`_
+    - Mobility (movement) data based on phone location data
+- `Symptom Surveys <https://cmu-delphi.github.io/delphi-epidata/api/covidcast-signals/fb-survey.html>`_
+    - Various responses to the CMU symptom survey.
+- `USAFacts Cases and Deaths <https://cmu-delphi.github.io/delphi-epidata/api/covidcast-signals/usa-facts.html>`_
+    - Confirmed COVID cases and deaths based on reports made available by USAFacts.
+
+To specify a signal, you will need the "Source Name" and "Signal" value, which are
+listed for each source/signal combination in their full description.
+For example, to obtain the raw Google search volume for COVID-related topics,
+the source would be ``ght`` and the signal would be ``raw_search``, as shown on the
+`page for that signal <https://cmu-delphi.github.io/delphi-epidata/api/covidcast-signals/ght.html>`_.
+These values will be provided as the arguments for the :py:func:`covidcast.signal` function to
+retrieve the desired data.
+
+
 
 Basic examples
 --------------

--- a/Python-packages/covidcast-py/docs/getting_started.rst
+++ b/Python-packages/covidcast-py/docs/getting_started.rst
@@ -12,7 +12,7 @@ This package provides access to data from the `COVIDcast API
 provides numerous COVID-related data streams, updated daily. The data is retrieved
 live from the server when you make a request, and is not stored within the package
 itself. This means that each time you make a request, you will be receiving the latest
-data. If you are conducting an analysis or powering a service which will require
+data available. If you are conducting an analysis or powering a service which will require
 repeated access to the same signal, please download the data rather than making repeated
 requests.
 
@@ -31,14 +31,14 @@ your favorite Python package manager:
 
 Signal Overview
 ---------------
-The `Delphi Epidata documentation
+The `API documentation
 <https://cmu-delphi.github.io/delphi-epidata/api/covidcast_signals.html>`_ lists
 the available signals, including many not shown on the
 `COVIDcast interactive map
 <https://covidcast.cmu.edu/>`_.
 
 The data come from a variety of sources and cover information including official case counts,
-internet search trends, hospital encounters, testing volume, survey responses, and more. Below is
+internet search trends, hospital encounters, survey responses, and more. Below is
 a brief overview of each source, with links to their full descriptions.
 
 - `Doctor Visits <https://cmu-delphi.github.io/delphi-epidata/api/covidcast-signals/doctor-visits.html>`_

--- a/Python-packages/covidcast-py/docs/index.rst
+++ b/Python-packages/covidcast-py/docs/index.rst
@@ -39,23 +39,6 @@ The package source code and bug tracker can be found `on GitHub
    research product and not warranted for a particular purpose.
 
 
-Installation
-------------
-
-This package is available on PyPI as `covidcast
-<https://pypi.org/project/covidcast/>`_, and can be installed using ``pip`` or
-your favorite Python package manager:
-
-.. code-block:: sh
-
-   pip install covidcast
-
-The package requires `pandas <https://pandas.pydata.org/>`_, `requests
-<https://requests.readthedocs.io/en/master/>`_, and several other packages;
-these should be installed automatically. It also uses the `delphi-epidata
-<https://pypi.org/project/delphi-epidata/>`_ package to access Delphi's Epidata
-API.
-
 Contents
 --------
 

--- a/Python-packages/covidcast-py/docs/index.rst
+++ b/Python-packages/covidcast-py/docs/index.rst
@@ -23,6 +23,8 @@ all the data sources and signals available through this API.
 The package source code and bug tracker can be found `on GitHub
 <https://github.com/cmu-delphi/covidcast>`_.
 
+To get started, check out :ref:`<getting-started>`.
+
 
 .. note :: **You should consider subscribing** to the `API mailing list
    <https://lists.andrew.cmu.edu/mailman/listinfo/delphi-covidcast-api>`_ to be

--- a/Python-packages/covidcast-py/docs/signals.rst
+++ b/Python-packages/covidcast-py/docs/signals.rst
@@ -1,8 +1,6 @@
 Fetching Data
 =============
 
-.. _obtaining-signals:
-
 Signals
 -------
 

--- a/Python-packages/covidcast-py/docs/signals.rst
+++ b/Python-packages/covidcast-py/docs/signals.rst
@@ -1,6 +1,8 @@
 Fetching Data
 =============
 
+.. _obtaining-signals:
+
 Signals
 -------
 


### PR DESCRIPTION
Addresses point 1 and 2 on #94

Summary of changes:
- Add section explaining the API
- Add an overview of sources and instructions on how to get the names to pass to covidcast.signal()
- Move installation info to "Getting Started"

I will say that the info duplication between this and the epidata api on sources (and the need to keep them in sync) is a bit messy, but probably ok for now. Also it probably looks better as a table, so I need to figure out how to get restructured tables to look good.

Once we finalize the language/structure, I can work on adding to the R docs as well.