### PR TITLE
Update README and add docstring style check

### DIFF
--- a/.github/workflows/python_ci.yml
+++ b/.github/workflows/python_ci.yml
@@ -30,6 +30,7 @@ jobs:
       run: |
         pylint Python-packages/covidcast-py/covidcast/ --rcfile Python-packages/covidcast-py/.pylintrc
         mypy Python-packages/covidcast-py/covidcast --config-file Python-packages/covidcast-py/mypy.ini
+        pydocstyle Python-packages/covidcast-py/covidcast/
     - name: Test with pytest
       run: |
         pytest Python-packages/covidcast-py/ -W ignore::UserWarning

--- a/Python-packages/covidcast-py/DEVELOP.md
+++ b/Python-packages/covidcast-py/DEVELOP.md
@@ -9,7 +9,7 @@ for organization and namespace purposes.
 Sphinx documentation is in the `docs/` folder. See "Building the Package and Documentation" below 
 for information on how to build the documentation.
 
-The CI workflow is stored in the repos top level directory in `.github/workflows/python_ci.yml`
+The CI workflow is stored in the repo's top level directory in `.github/workflows/python_ci.yml`
 
 ## Development
 These are general recommendations for developing. They do not have to be strictly followed, 
@@ -33,7 +33,7 @@ __Style__
 `pylint` in `.pylintrc` and for `mypy` in `mypy.ini`.
 
 __Testing__
-- `pytest` is the framework used in this package
+- `pytest` is the framework used in this package.
 - Each function should have corresponding unit tests. 
 - Tests should be deterministic.
 - Similarly, tests should not make network calls.

--- a/Python-packages/covidcast-py/DEVELOP.md
+++ b/Python-packages/covidcast-py/DEVELOP.md
@@ -1,14 +1,65 @@
 # Developing the covidcast package
 
+## Structure
+From `covidcast/Python-packages/covidcast-py`, the Python library files are located in the 
+`covidcast/` folder, with corresponding tests in `tests/covidcast/`. 
+Currently, primary user facing functions across the modules are being imported in `covidcast/__init__.py` 
+for organization and namespace purposes.
+
+Sphinx documentation is in the `docs/` folder. See "Building the Package and Documentation" below 
+for information on how to build the documentation.
+
+The CI workflow is stored in the repos top level directory in `.github/workflows/python_ci.yml`
+
+## Development
+These are general recommendations for developing. They do not have to be strictly followed, 
+but are encouraged. 
+
+__Environment__
+- A virtual environment is recommended, which can be started with the following commands:
+
+    ```sh
+    python3 -m venv env
+    source env/bin/activate
+    ```
+    this will create an `env/` folder containing files required in the environment, which
+    is gitignored. The environment can be deactived by running `deactivate`, and reactived by
+    rerunning `source env/bin/activate`. To create a new environment, you can delete the 
+    `env/` folder and rerun the above commands if you do not require the old one anymore, 
+    or rerun the above command with a new environment name in place of `env`.
+
+__Style__
+- `mypy`, `pylint`, and `pydocstyle` are used for linting, with associated configurations for 
+`pylint` in `.pylintrc` and for `mypy` in `mypy.ini`.
+
+__Testing__
+- `pytest` is the framework used in this package
+- Each function should have corresponding unit tests. 
+- Tests should be deterministic.
+- Similarly, tests should not make network calls.
+
+__Documentation__
+- New public methods should have comprehensive docstrings and 
+an entry in the Sphinx documentation.
+- Usage examples in Sphinx are recommended.
+
+## Building the Package and Documentation
 The package is fairly straightforward in structure, following the basic
 [packaging
 documentation](https://packaging.python.org/tutorials/packaging-projects/) and a
 few other pieces I found.
 
-When you develop a new package version, there are several steps to consider:
+When you develop a new package version, there are several steps to consider. 
+These are written from the `Python-packages/covidcast-py/` directory:
 
 1. Increment the package version in `setup.py` and in Sphinx's `conf.py`.
-2. Rebuild the package. You will need to install the `wheel` package:
+2. Install the requirements needed to build the package and documentation:
+
+    ```sh
+    pip3 install -r requirements_dev.txt
+    ```
+   
+3. Rebuild the package:
 
     ```sh
     python3 setup.py clean
@@ -16,8 +67,12 @@ When you develop a new package version, there are several steps to consider:
     ```
 
     Verify the build worked without errors.
-3. Locally install the package with `python3 setup.py install`.
-4. Install dependencies  with `pip3 install -r requirements.txt`
+4. Locally install the package:
+    
+    ```sh
+    pip3 install .
+    ```
+   
 5. Rebuild the documentation. The documentation lives in `docs/` and is built by
    [Sphinx](https://www.sphinx-doc.org/en/master/), which automatically reads
    the function docstrings and formats them. `docs/index.rst` contains the main
@@ -28,6 +83,7 @@ When you develop a new package version, there are several steps to consider:
 
     ```sh
     cd docs/
+    make clean
     make html
     ```
 
@@ -36,7 +92,7 @@ When you develop a new package version, there are several steps to consider:
 
     If you make changes to `index.rst`, you can simply run `make html` to
     rebuild without needing to reinstall the package.
-4. Upload to PyPI. It should be as easy as
+6. Upload to PyPI. It should be as easy as
 
     ```sh
     twine upload dist/covidcast-0.0.9*

--- a/Python-packages/covidcast-py/covidcast/covidcast.py
+++ b/Python-packages/covidcast-py/covidcast/covidcast.py
@@ -147,7 +147,6 @@ def signal(data_source: str,
     specific signals.
 
     """
-
     if geo_type not in VALID_GEO_TYPES:
         raise ValueError("geo_type must be one of " + ", ".join(VALID_GEO_TYPES))
 
@@ -239,7 +238,6 @@ def metadata() -> pd.DataFrame:
         The sample standard deviation of all reported values.
 
     """
-
     meta = Epidata.covidcast_meta()
 
     if meta["result"] != 1:
@@ -351,7 +349,6 @@ def _fetch_single_geo(data_source: str,
     entries.
 
     """
-
     as_of_str = _date_to_api_string(as_of) if as_of is not None else None
     issues_strs = _dates_to_api_strings(issues) if issues is not None else None
 
@@ -398,7 +395,6 @@ def _signal_metadata(data_source: str,
                      signal: str,  # pylint: disable=W0621
                      geo_type: str) -> dict:
     """Fetch metadata for a single signal as a dict."""
-
     meta = metadata()
 
     mask = ((meta.data_source == data_source) &
@@ -423,13 +419,11 @@ def _signal_metadata(data_source: str,
 
 def _date_to_api_string(date: date) -> str:  # pylint: disable=W0621
     """Convert a date object to a YYYYMMDD string expected by the API."""
-
     return date.strftime("%Y%m%d")
 
 
 def _dates_to_api_strings(dates: Union[date, list, tuple]) -> str:
     """Convert a date object, or pair of (start, end) objects, to YYYYMMDD strings."""
-
     if not isinstance(dates, (list, tuple)):
         return _date_to_api_string(dates)
 

--- a/Python-packages/covidcast-py/covidcast/geography.py
+++ b/Python-packages/covidcast-py/covidcast/geography.py
@@ -1,3 +1,4 @@
+"""Functions for converting and mapping between geographic types."""
 import re
 import warnings
 from typing import Union, Iterable
@@ -237,7 +238,7 @@ def _lookup(key: Union[str, Iterable],
 
 
 def _get_first_tie(dict_list: list) -> list:
-    """Return a list with the first value for the first key for each of the input dicts
+    """Return a list with the first value for the first key for each of the input dicts.
 
     Needs to be Python 3.6+ for this to work, since earlier versions don't preserve insertion order.
 

--- a/Python-packages/covidcast-py/covidcast/plotting.py
+++ b/Python-packages/covidcast-py/covidcast/plotting.py
@@ -71,7 +71,6 @@ def plot_choropleth(data: pd.DataFrame,
     :return: Matplotlib figure object.
 
     """
-
     data_source, signal, geo_type = _detect_metadata(data)  # pylint: disable=W0212
     meta = _signal_metadata(data_source, signal, geo_type)  # pylint: disable=W0212
     # use most recent date in data if none provided
@@ -157,7 +156,6 @@ def get_geo_df(data: pd.DataFrame,
       WGS84 for HRRs.
 
     """
-
     if join_type == "right" and any(data[geo_value_col].duplicated()):
         raise ValueError("join_type `right` is incompatible with duplicate values in a "
                          "given region. Use `left` or ensure your input data is a single signal for"

--- a/Python-packages/covidcast-py/requirements.txt
+++ b/Python-packages/covidcast-py/requirements.txt
@@ -1,5 +1,6 @@
 pylint
 pytest
+pydocstyle
 delphi_epidata
 pandas
 geopandas

--- a/Python-packages/covidcast-py/requirements_dev.txt
+++ b/Python-packages/covidcast-py/requirements_dev.txt
@@ -1,0 +1,3 @@
+sphinx
+sphinx-autodoc-typehints
+wheel


### PR DESCRIPTION
Closes #97 

Summary of changes:
- Add `pydocstyle` to lint docstrings
- Update developer readme with some more info. It's a bit bare still but better than nothing
- Add a requirements_dev.txt file with some packages that are needed for building the package and docs.