### PR TITLE
Python client: Remove `Direction` field from output and documentation

### DIFF
--- a/Python-packages/covidcast-py/covidcast/covidcast.py
+++ b/Python-packages/covidcast-py/covidcast/covidcast.py
@@ -136,11 +136,6 @@ def signal(data_source: str,
         sample size may not be available for all signals, due to privacy or
         other constraints.
 
-      ``direction``
-        uses a local linear fit to estimate whether the signal in this region is
-        currently increasing or decreasing (reported as -1 for decreasing, 1 for
-        increasing, and 0 for neither).
-
     Consult the `signal documentation
     <https://cmu-delphi.github.io/delphi-epidata/api/covidcast_signals.html>`_
     for more details on how values and standard errors are calculated for
@@ -380,7 +375,7 @@ def _fetch_single_geo(data_source: str,
 
     if len(dfs) > 0:
         out = pd.concat(dfs)
-
+        out.drop("direction", axis=1, inplace=True)
         out["time_value"] = pd.to_datetime(out["time_value"], format="%Y%m%d")
         out["issue"] = pd.to_datetime(out["issue"], format="%Y%m%d")
         out["geo_type"] = geo_type

--- a/Python-packages/covidcast-py/docs/changelog.rst
+++ b/Python-packages/covidcast-py/docs/changelog.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+v0.1.1, TODO
+- ``Direction`` is no longer supported and has been removed from the output
+  of :py:func:`covidcast.signal`
+
+
 v0.1.0, October 1, 2020
 -----------------------
 

--- a/Python-packages/covidcast-py/docs/getting_started.rst
+++ b/Python-packages/covidcast-py/docs/getting_started.rst
@@ -84,12 +84,12 @@ distributed through Facebook, for every county in the United States between
 ...                         date(2020, 5, 1), date(2020, 5, 7),
 ...                         "county")
 >>> data.head()
-   direction geo_value      issue  lag  sample_size    stderr time_value     value
-0        0.0     01000 2020-05-23   22    1722.4551  0.125573 2020-05-01  0.823080
-1        1.0     01001 2020-05-23   22     115.8025  0.800444 2020-05-01  1.261261
-2        0.0     01003 2020-05-23   22     584.3194  0.308680 2020-05-01  0.665129
-3        0.0     01015 2020-05-23   22     122.5577  0.526590 2020-05-01  0.574713
-4        NaN     01031 2020-05-23   22     114.8318  0.347450 2020-05-01  0.408163
+   geo_value      issue  lag  sample_size    stderr time_value     value
+0      01000 2020-05-23   22    1722.4551  0.125573 2020-05-01  0.823080
+1      01001 2020-05-23   22     115.8025  0.800444 2020-05-01  1.261261
+2      01003 2020-05-23   22     584.3194  0.308680 2020-05-01  0.665129
+3      01015 2020-05-23   22     122.5577  0.526590 2020-05-01  0.574713
+4      01031 2020-05-23   22     114.8318  0.347450 2020-05-01  0.408163
 
 Each row represents one observation in one county on one day. The county FIPS
 code is given in the ``geo_value`` column, the date in the ``time_value``
@@ -115,12 +115,12 @@ example, we obtain ``smoothed_cli`` in each state for every day since
 >>> data = covidcast.signal("fb-survey", "smoothed_cli",
 ...                         date(2020, 5, 1), geo_type="state")
 >>> data.head()
-   direction geo_value      issue  lag  sample_size    stderr time_value     value
-0       -1.0        ak 2020-05-23   22    1606.0000  0.158880 2020-05-01  0.460772
-1        0.0        al 2020-05-23   22    7540.2437  0.082553 2020-05-01  0.699511
-2       -1.0        ar 2020-05-23   22    4921.4827  0.103651 2020-05-01  0.759798
-3        0.0        az 2020-05-23   22   11220.9587  0.061794 2020-05-01  0.566937
-4        0.0        ca 2020-05-23   22   51870.1382  0.022803 2020-05-01  0.364908
+   geo_value      issue  lag  sample_size    stderr time_value     value
+0         ak 2020-05-23   22    1606.0000  0.158880 2020-05-01  0.460772
+1         al 2020-05-23   22    7540.2437  0.082553 2020-05-01  0.699511
+2         ar 2020-05-23   22    4921.4827  0.103651 2020-05-01  0.759798
+3         az 2020-05-23   22   11220.9587  0.061794 2020-05-01  0.566937
+4         ca 2020-05-23   22   51870.1382  0.022803 2020-05-01  0.364908
 
 Using the ``geo_values`` argument, we can request data for a specific geography,
 such as the state of Pennsylvania for the month of May 2020:
@@ -129,12 +129,12 @@ such as the state of Pennsylvania for the month of May 2020:
 ...                            date(2020, 5, 1), date(2020, 5, 31),
 ...                            geo_type="state", geo_values="pa")
 >>> pa_data.head()
-   direction geo_value      issue  lag  sample_size    stderr time_value     value
-0         -1        pa 2020-05-23   22   31576.0165  0.030764 2020-05-01  0.400011
-0         -1        pa 2020-05-23   21   31344.0168  0.030708 2020-05-02  0.394774
-0          0        pa 2020-05-23   20   30620.0162  0.031173 2020-05-03  0.396340
-0         -1        pa 2020-05-23   19   30419.0163  0.029836 2020-05-04  0.357501
-0          0        pa 2020-05-23   18   29245.0172  0.030176 2020-05-05  0.354521
+   geo_value      issue  lag  sample_size    stderr time_value     value
+0         pa 2020-05-23   22   31576.0165  0.030764 2020-05-01  0.400011
+0         pa 2020-05-23   21   31344.0168  0.030708 2020-05-02  0.394774
+0         pa 2020-05-23   20   30620.0162  0.031173 2020-05-03  0.396340
+0         pa 2020-05-23   19   30419.0163  0.029836 2020-05-04  0.357501
+0         pa 2020-05-23   18   29245.0172  0.030176 2020-05-05  0.354521
 
 We can request multiple states by providing a list, such as ``["pa", "ny",
 "mo"]``.
@@ -203,8 +203,8 @@ the ``as_of`` argument:
 ...                  start_day=date(2020, 5, 1), end_day=date(2020, 5, 1),
 ...                  geo_type="state", geo_values="pa",
 ...                  as_of=date(2020, 5, 7))
-   direction geo_value      issue  lag sample_size stderr time_value    value
-0         -1        pa 2020-05-07    6        None   None 2020-05-01  2.32192
+   geo_value      issue  lag sample_size stderr time_value    value
+0         pa 2020-05-07    6        None   None 2020-05-01  2.32192
 
 This shows that an estimate of about 2.3% was issued on May 7. If we don't
 specify ``as_of``, we get the most recent estimate available:
@@ -212,8 +212,8 @@ specify ``as_of``, we get the most recent estimate available:
 >>> covidcast.signal("doctor-visits", "smoothed_cli",
 ...                  start_day=date(2020, 5, 1), end_day=date(2020, 5, 1),
 ...                  geo_type="state", geo_values="pa")
-   direction geo_value      issue  lag sample_size stderr time_value     value
-0         -1        pa 2020-07-04   64        None   None 2020-05-01  5.075015
+   geo_value      issue  lag sample_size stderr time_value     value
+0         pa 2020-07-04   64        None   None 2020-05-01  5.075015
 
 Note the substantial change in the estimate, to over 5%, reflecting new data
 that became available *after* May 7 about visits occurring on May 1. This
@@ -229,16 +229,16 @@ period:
 ...                  start_day=date(2020, 5, 1), end_day=date(2020, 5, 1),
 ...                  geo_type="state", geo_values="pa",
 ...                  issues=(date(2020, 5, 1), date(2020, 5, 15)))
-   direction geo_value      issue  lag sample_size stderr time_value     value
-0         -1        pa 2020-05-05    4        None   None 2020-05-01  1.693061
-1         -1        pa 2020-05-06    5        None   None 2020-05-01  2.524167
-2         -1        pa 2020-05-07    6        None   None 2020-05-01  2.321920
-3          0        pa 2020-05-08    7        None   None 2020-05-01  2.897032
-4          0        pa 2020-05-09    8        None   None 2020-05-01  2.956456
-5          0        pa 2020-05-12   11        None   None 2020-05-01  3.190634
-6          0        pa 2020-05-13   12        None   None 2020-05-01  3.220023
-7          0        pa 2020-05-14   13        None   None 2020-05-01  3.231314
-8          0        pa 2020-05-15   14        None   None 2020-05-01  3.239970
+   geo_value      issue  lag sample_size stderr time_value     value
+0         pa 2020-05-05    4        None   None 2020-05-01  1.693061
+1         pa 2020-05-06    5        None   None 2020-05-01  2.524167
+2         pa 2020-05-07    6        None   None 2020-05-01  2.321920
+3         pa 2020-05-08    7        None   None 2020-05-01  2.897032
+4         pa 2020-05-09    8        None   None 2020-05-01  2.956456
+5         pa 2020-05-12   11        None   None 2020-05-01  3.190634
+6         pa 2020-05-13   12        None   None 2020-05-01  3.220023
+7         pa 2020-05-14   13        None   None 2020-05-01  3.231314
+8         pa 2020-05-15   14        None   None 2020-05-01  3.239970
 
 This estimate was clearly updated many times as new data for May 1st arrived.
 Note that these results include only data issued or updated between 2020-05-01
@@ -253,12 +253,12 @@ issues 7 days after the corresponding ``time_value``:
 >>> covidcast.signal("doctor-visits", "smoothed_cli",
 ...                  start_day=date(2020, 5, 1), end_day=date(2020, 5, 7),
 ...                  geo_type="state", geo_values="pa", lag=7)
-   direction geo_value      issue  lag sample_size stderr time_value     value
-0          0        pa 2020-05-08    7        None   None 2020-05-01  2.897032
-0         -1        pa 2020-05-09    7        None   None 2020-05-02  2.802238
-0          0        pa 2020-05-12    7        None   None 2020-05-05  3.483125
-0          0        pa 2020-05-13    7        None   None 2020-05-06  2.968670
-0          0        pa 2020-05-14    7        None   None 2020-05-07  2.400255
+   geo_value      issue  lag sample_size stderr time_value     value
+0         pa 2020-05-08    7        None   None 2020-05-01  2.897032
+0         pa 2020-05-09    7        None   None 2020-05-02  2.802238
+0         pa 2020-05-12    7        None   None 2020-05-05  3.483125
+0         pa 2020-05-13    7        None   None 2020-05-06  2.968670
+0         pa 2020-05-14    7        None   None 2020-05-07  2.400255
 
 Note that though this query requested all values between 2020-05-01 and
 2020-05-07, May 3rd and May 4th were *not* included in the results set. This is
@@ -269,12 +269,12 @@ on May 10th (a 7-day lag), but in fact the value was not updated on that day:
 ...                  start_day=date(2020, 5, 3), end_day=date(2020, 5, 3),
 ...                  geo_type="state", geo_values="pa",
 ...                  issues=(date(2020, 5, 9), date(2020, 5, 15)))
-   direction geo_value      issue  lag sample_size stderr time_value     value
-0         -1        pa 2020-05-09    6        None   None 2020-05-03  2.749537
-1         -1        pa 2020-05-12    9        None   None 2020-05-03  2.989626
-2         -1        pa 2020-05-13   10        None   None 2020-05-03  3.006860
-3         -1        pa 2020-05-14   11        None   None 2020-05-03  2.970561
-4         -1        pa 2020-05-15   12        None   None 2020-05-03  3.038054
+   geo_value      issue  lag sample_size stderr time_value     value
+0         pa 2020-05-09    6        None   None 2020-05-03  2.749537
+1         pa 2020-05-12    9        None   None 2020-05-03  2.989626
+2         pa 2020-05-13   10        None   None 2020-05-03  3.006860
+3         pa 2020-05-14   11        None   None 2020-05-03  2.970561
+4         pa 2020-05-15   12        None   None 2020-05-03  3.038054
 
 Dealing with geographies
 ------------------------
@@ -297,10 +297,10 @@ We can use these functions to quickly query data for specific regions:
 ...                       start_day=date(2020, 5, 1), end_day=date(2020, 5, 1),
 ...                       geo_values=counties)
 >>> df
-  geo_value        signal time_value  direction      issue  lag     value stderr sample_size geo_type    data_source
-0     42003  smoothed_cli 2020-05-01         -1 2020-07-04   64  1.336086   None        None   county  doctor-visits
-0     06037  smoothed_cli 2020-05-01          0 2020-07-04   64  5.787655   None        None   county  doctor-visits
-0     12086  smoothed_cli 2020-05-01         -1 2020-07-04   64  6.405477   None        None   county  doctor-visits
+  geo_value        signal time_value      issue  lag     value stderr sample_size geo_type    data_source
+0     42003  smoothed_cli 2020-05-01 2020-07-04   64  1.336086   None        None   county  doctor-visits
+0     06037  smoothed_cli 2020-05-01 2020-07-04   64  5.787655   None        None   county  doctor-visits
+0     12086  smoothed_cli 2020-05-01 2020-07-04   64  6.405477   None        None   county  doctor-visits
 
 
 We can also quickly convert back from the IDs returned by the API to

--- a/Python-packages/covidcast-py/docs/plot_examples.rst
+++ b/Python-packages/covidcast-py/docs/plot_examples.rst
@@ -191,35 +191,35 @@ with the ``join_type`` argument.
 ...                         date(2020, 8, 4),
 ...                         geo_type = "county")
 >>> covidcast.get_geo_df(data)
-     geo_value time_value  direction      issue  lag     value    stderr  sample_size geo_type data_source        signal                                           geometry state_fips
-0        24510 2020-08-04        NaN 2020-08-06  2.0  0.375601  0.193356     587.6289   county   fb-survey  smoothed_cli  POLYGON ((-76.71131 39.37193, -76.62619 39.372...         24
-1        31169 2020-08-04        NaN 2020-08-06  2.0  0.928208  0.168783    1059.8130   county   fb-survey  smoothed_cli  POLYGON ((-97.82082 40.35054, -97.36869 40.350...         31
-2        37077 2020-08-04        NaN 2020-08-06  2.0  0.627742  0.081884    3146.0176   county   fb-survey  smoothed_cli  POLYGON ((-78.80252 36.21349, -78.80235 36.220...         37
-3        46091 2020-08-04        NaN 2020-08-06  2.0  0.589745  0.161989     778.7429   county   fb-survey  smoothed_cli  POLYGON ((-97.97924 45.76257, -97.97878 45.935...         46
-4        39075 2020-08-04        NaN 2020-08-06  2.0  0.785641  0.099959    2767.5054   county   fb-survey  smoothed_cli  POLYGON ((-82.22066 40.66758, -82.12620 40.668...         39
-...        ...        ...        ...        ...  ...       ...       ...          ...      ...         ...           ...                                                ...        ...
-3228     53055 2020-08-04        NaN 2020-08-06  2.0  0.440817  0.143404     944.1731   county   fb-survey  smoothed_cli  MULTIPOLYGON (((-122.97714 48.79345, -122.9379...         53
-3229     39133 2020-08-04        NaN 2020-08-06  2.0  0.040082  0.089324     310.8495   county   fb-survey  smoothed_cli  POLYGON ((-81.39328 41.02544, -81.39322 41.040...         39
-3230     08025 2020-08-04        NaN 2020-08-06  2.0  0.440306  0.123763    1171.5823   county   fb-survey  smoothed_cli  POLYGON ((-104.05840 38.26084, -104.05392 38.5...         08
-3231     13227 2020-08-04        NaN 2020-08-06  2.0  1.009511  0.092993    3605.8731   county   fb-survey  smoothed_cli  POLYGON ((-84.65437 34.54895, -84.52139 34.550...         13
-3232     21145 2020-08-04        NaN 2020-08-06  2.0  1.257862  0.915558     150.4266   county   fb-survey  smoothed_cli  POLYGON ((-88.93308 37.22775, -88.93174 37.227...         21
+     geo_value time_value      issue  lag     value    stderr  sample_size geo_type data_source        signal                                           geometry state_fips
+0        24510 2020-08-04 2020-08-06  2.0  0.375601  0.193356     587.6289   county   fb-survey  smoothed_cli  POLYGON ((-76.71131 39.37193, -76.62619 39.372...         24
+1        31169 2020-08-04 2020-08-06  2.0  0.928208  0.168783    1059.8130   county   fb-survey  smoothed_cli  POLYGON ((-97.82082 40.35054, -97.36869 40.350...         31
+2        37077 2020-08-04 2020-08-06  2.0  0.627742  0.081884    3146.0176   county   fb-survey  smoothed_cli  POLYGON ((-78.80252 36.21349, -78.80235 36.220...         37
+3        46091 2020-08-04 2020-08-06  2.0  0.589745  0.161989     778.7429   county   fb-survey  smoothed_cli  POLYGON ((-97.97924 45.76257, -97.97878 45.935...         46
+4        39075 2020-08-04 2020-08-06  2.0  0.785641  0.099959    2767.5054   county   fb-survey  smoothed_cli  POLYGON ((-82.22066 40.66758, -82.12620 40.668...         39
+...        ...        ...       ...        ...  ...       ...       ...          ...      ...         ...           ...                                                ...        ...
+3228     53055 2020-08-04 2020-08-06  2.0  0.440817  0.143404     944.1731   county   fb-survey  smoothed_cli  MULTIPOLYGON (((-122.97714 48.79345, -122.9379...         53
+3229     39133 2020-08-04 2020-08-06  2.0  0.040082  0.089324     310.8495   county   fb-survey  smoothed_cli  POLYGON ((-81.39328 41.02544, -81.39322 41.040...         39
+3230     08025 2020-08-04 2020-08-06  2.0  0.440306  0.123763    1171.5823   county   fb-survey  smoothed_cli  POLYGON ((-104.05840 38.26084, -104.05392 38.5...         08
+3231     13227 2020-08-04 2020-08-06  2.0  1.009511  0.092993    3605.8731   county   fb-survey  smoothed_cli  POLYGON ((-84.65437 34.54895, -84.52139 34.550...         13
+3232     21145 2020-08-04 2020-08-06  2.0  1.257862  0.915558     150.4266   county   fb-survey  smoothed_cli  POLYGON ((-88.93308 37.22775, -88.93174 37.227...         21
 [3233 rows x 13 columns]
 
 Note that there are 3233 output rows for the 3233 counties present in the Census shapefiles.
 
 >>> covidcast.get_geo_df(covid, join_type="left")
-    geo_value time_value direction      issue  lag     value    stderr  sample_size geo_type data_source        signal                                           geometry state_fips
-0       01000 2020-08-04      None 2020-08-06    2  1.153447  0.136070    1759.8539   county   fb-survey  smoothed_cli                                               None        NaN
-1       01001 2020-08-04      None 2020-08-06    2  0.539568  0.450588     107.9345   county   fb-survey  smoothed_cli  POLYGON ((-86.91759 32.66417, -86.81657 32.660...         01
-2       01003 2020-08-04      None 2020-08-06    2  1.625496  0.522036     455.2964   county   fb-survey  smoothed_cli  POLYGON ((-88.02927 30.22271, -88.02399 30.230...         01
-3       01015 2020-08-04      None 2020-08-06    2  0.000000  0.378788     115.2302   county   fb-survey  smoothed_cli  POLYGON ((-86.14371 33.70913, -86.12388 33.710...         01
-4       01051 2020-08-04      None 2020-08-06    2  0.786565  0.435877     112.5569   county   fb-survey  smoothed_cli  POLYGON ((-86.41333 32.75059, -86.37497 32.753...         01
-..        ...        ...       ...        ...  ...       ...       ...          ...      ...         ...           ...                                                ...        ...
-840     55141 2020-08-04      None 2020-08-06    2  1.190476  0.867751     144.3682   county   fb-survey  smoothed_cli  POLYGON ((-90.31605 44.42450, -90.31596 44.424...         55
-841     56000 2020-08-04      None 2020-08-06    2  0.822092  0.254670     628.9937   county   fb-survey  smoothed_cli                                               None        NaN
-842     56021 2020-08-04      None 2020-08-06    2  0.269360  0.315094     197.9646   county   fb-survey  smoothed_cli  POLYGON ((-105.28064 41.33100, -105.27824 41.6...         56
-843     56025 2020-08-04      None 2020-08-06    2  0.170940  0.304654     192.0237   county   fb-survey  smoothed_cli  POLYGON ((-107.54353 42.78156, -107.50142 42.7...         56
-844     72000 2020-08-04      None 2020-08-06    2  0.000000  0.228310     100.9990   county   fb-survey  smoothed_cli                                               None        NaN
+    geo_value time_value      issue  lag     value    stderr  sample_size geo_type data_source        signal                                           geometry state_fips
+0       01000 2020-08-04 2020-08-06    2  1.153447  0.136070    1759.8539   county   fb-survey  smoothed_cli                                               None        NaN
+1       01001 2020-08-04 2020-08-06    2  0.539568  0.450588     107.9345   county   fb-survey  smoothed_cli  POLYGON ((-86.91759 32.66417, -86.81657 32.660...         01
+2       01003 2020-08-04 2020-08-06    2  1.625496  0.522036     455.2964   county   fb-survey  smoothed_cli  POLYGON ((-88.02927 30.22271, -88.02399 30.230...         01
+3       01015 2020-08-04 2020-08-06    2  0.000000  0.378788     115.2302   county   fb-survey  smoothed_cli  POLYGON ((-86.14371 33.70913, -86.12388 33.710...         01
+4       01051 2020-08-04 2020-08-06    2  0.786565  0.435877     112.5569   county   fb-survey  smoothed_cli  POLYGON ((-86.41333 32.75059, -86.37497 32.753...         01
+..        ...        ...        ...  ...       ...       ...          ...      ...         ...           ...                                                ...        ...
+840     55141 2020-08-04 2020-08-06    2  1.190476  0.867751     144.3682   county   fb-survey  smoothed_cli  POLYGON ((-90.31605 44.42450, -90.31596 44.424...         55
+841     56000 2020-08-04 2020-08-06    2  0.822092  0.254670     628.9937   county   fb-survey  smoothed_cli                                               None        NaN
+842     56021 2020-08-04 2020-08-06    2  0.269360  0.315094     197.9646   county   fb-survey  smoothed_cli  POLYGON ((-105.28064 41.33100, -105.27824 41.6...         56
+843     56025 2020-08-04 2020-08-06    2  0.170940  0.304654     192.0237   county   fb-survey  smoothed_cli  POLYGON ((-107.54353 42.78156, -107.50142 42.7...         56
+844     72000 2020-08-04 2020-08-06    2  0.000000  0.228310     100.9990   county   fb-survey  smoothed_cli                                               None        NaN
 [845 rows x 13 columns]
 
 With the left join, there are 845 rows since the signal returned information for 845 counties and

--- a/Python-packages/covidcast-py/tests/covidcast/test_covidcast.py
+++ b/Python-packages/covidcast-py/tests/covidcast/test_covidcast.py
@@ -22,7 +22,9 @@ def sort_df(df):
 @patch("delphi_epidata.Epidata.covidcast")
 def test_signal(mock_covidcast, mock_metadata):
     mock_covidcast.return_value = {"result": 1,  # successful API response
-                                   "epidata": [{"time_value": 20200622, "issue": 20200724}],
+                                   "epidata": [{"time_value": 20200622,
+                                                "issue": 20200724,
+                                                "direction": None}],
                                    "message": "success"}
     mock_metadata.return_value = {"max_time": pd.Timestamp("2020-08-04 00:00:00"),
                                   "min_time": pd.Timestamp("2020-08-03 00:00:00")}
@@ -194,10 +196,13 @@ def test__detect_metadata():
 def test__fetch_single_geo(mock_covidcast):
     # not generating full DF since most attributes used
     mock_covidcast.side_effect = [{"result": 1,  # successful API response
-                                   "epidata": [{"time_value": 20200622, "issue": 20200724}],
+                                   "epidata": [{"time_value": 20200622,
+                                                "issue": 20200724,
+                                                "direction": None}],
                                    "message": "success"},
                                   {"result": 1,  # second successful API
-                                   "epidata": [{"time_value": 20200821, "issue": 20200925}],
+                                   "epidata": [{"time_value": 20200821,
+                                                "issue": 20200925}],
                                    "message": "success"},
                                   {"message": "error: failed"},  # unsuccessful API response
                                   {"message": "success"}]  # no epidata


### PR DESCRIPTION
Summary of changes:
- Remove the `direction` field, which has been null since August, from signal() output
- Update tests
- Remove corresponding documentation
- Add placeholder in changelog