### PR TITLE
Add function for converting State Abbreviation to/from FIPS

### DIFF
--- a/Python-packages/covidcast-py/covidcast/__init__.py
+++ b/Python-packages/covidcast-py/covidcast/__init__.py
@@ -15,4 +15,5 @@ Functions:
 from .covidcast import signal, metadata, aggregate_signals
 from .plotting import plot, plot_choropleth, get_geo_df, animate
 from .geography import (fips_to_name, cbsa_to_name, abbr_to_name,
-                        name_to_abbr, name_to_cbsa, name_to_fips)
+                        name_to_abbr, name_to_cbsa, name_to_fips,
+                        fips_to_abbr, abbr_to_fips)

--- a/Python-packages/covidcast-py/covidcast/geography.py
+++ b/Python-packages/covidcast-py/covidcast/geography.py
@@ -16,6 +16,11 @@ STATE_CENSUS = pd.read_csv(
 # Filter undesired rows from CSVs.
 # They're not removed from the files to keep them identical to rda files.
 STATE_CENSUS = STATE_CENSUS.loc[STATE_CENSUS.STATE != "0"]
+# pad to 2 characters with leading 0s
+STATE_CENSUS["STATE"] = STATE_CENSUS["STATE"].str.zfill(2)
+# add 000 to the end to get a 5 digit code
+STATE_CENSUS["STATE"] = STATE_CENSUS["STATE"].str.pad(width=5, fillchar="0", side="right")
+# filter out micropolitan areas
 MSA_CENSUS = MSA_CENSUS.loc[MSA_CENSUS.LSAD == "Metropolitan Statistical Area"]
 
 
@@ -128,6 +133,33 @@ def name_to_abbr(name: Union[str, Iterable],
     return _lookup(name, STATE_CENSUS.NAME, STATE_CENSUS.ABBR, ignore_case, fixed, ties_method)
 
 
+def fips_to_abbr(code: Union[str, Iterable],
+                 ignore_case: bool = False,
+                 fixed: bool = False,
+                 ties_method: str = "first") -> list:
+    """Look up state abbreviation by FIPS codes with regular expression support.
+
+    Given an individual or list of FIPS codes or regular expressions, look up the corresponding
+    state abbreviation
+
+    :param code: Individual or list of FIPS codes or regular expressions.
+    :param ignore_case: Boolean for whether or not to be case insensitive in the regular expression.
+      If ``fixed=True``, this argument is ignored. Defaults to ``False``.
+    :param fixed: Conduct an exact case sensitive match with the input string.
+      Defaults to ``False``.
+    :param ties_method: Method for determining how to deal with multiple outputs for a given input.
+      Must be one of ``"all"`` or ``"first"``. If ``"first"``, then only the first match for each
+      code is returned. If ``"all"``, then all matches for each code are returned.
+      Defaults to ``first``.
+    :return: If ``ties_method="first"``, returns a list of the first value found for each input key.
+      If ``ties_method="all"``, returns a list of dicts, one for each input, with keys
+      corresponding to all matched input keys and values corresponding to the list of county names.
+      The returned list will be the same length as the input, with ``None`` or ``{}`` if no values
+      are found for ``ties_method="first"`` and ``ties_method="all"``, respectively.
+    """
+    return _lookup(code, STATE_CENSUS.STATE, STATE_CENSUS.ABBR, ignore_case, fixed, ties_method)
+
+
 def name_to_cbsa(name: Union[str, Iterable],
                  ignore_case: bool = False,
                  fixed: bool = False,
@@ -160,6 +192,34 @@ def name_to_cbsa(name: Union[str, Iterable],
     else:
         df = MSA_CENSUS
     return _lookup(name, df.NAME, df.CBSA, ignore_case, fixed, ties_method)
+
+
+def abbr_to_fips(code: Union[str, Iterable],
+                 ignore_case: bool = False,
+                 fixed: bool = False,
+                 ties_method: str = "first") -> list:
+    """Look up state FIPS codes by abbreviation with regular expression support.
+
+    Given an individual or list of state abbreviations or regular expressions,
+    look up the corresponding state FIPS codes. The returned codes are 5 digits and
+    end with 000.
+
+    :param code: Individual or list of abbreviations or regular expressions.
+    :param ignore_case: Boolean for whether or not to be case insensitive in the regular expression.
+      If ``fixed=True``, this argument is ignored. Defaults to ``False``.
+    :param fixed: Conduct an exact case sensitive match with the input string.
+      Defaults to ``False``.
+    :param ties_method: Method for determining how to deal with multiple outputs for a given input.
+      Must be one of ``"all"`` or ``"first"``. If ``"first"``, then only the first match for each
+      code is returned. If ``"all"``, then all matches for each code are returned.
+      Defaults to ``first``.
+    :return: If ``ties_method="first"``, returns a list of the first value found for each input key.
+      If ``ties_method="all"``, returns a list of dicts, one for each input, with keys
+      corresponding to all matched input keys and values corresponding to the list of county names.
+      The returned list will be the same length as the input, with ``None`` or ``{}`` if no values
+      are found for ``ties_method="first"`` and ``ties_method="all"``, respectively.
+    """
+    return _lookup(code, STATE_CENSUS.ABBR, STATE_CENSUS.STATE, ignore_case, fixed, ties_method)
 
 
 def name_to_fips(name: Union[str, Iterable],

--- a/Python-packages/covidcast-py/covidcast/geography.py
+++ b/Python-packages/covidcast-py/covidcast/geography.py
@@ -140,7 +140,8 @@ def fips_to_abbr(code: Union[str, Iterable],
     """Look up state abbreviation by FIPS codes with regular expression support.
 
     Given an individual or list of FIPS codes or regular expressions, look up the corresponding
-    state abbreviation
+    state abbreviation. FIPS codes can be the 2 digit code (``covidcast.fips_to_abbr("12")``) or
+    the 2 digit code with 000 appended to the end (``covidcast.fips_to_abbr("12000")``.
 
     :param code: Individual or list of FIPS codes or regular expressions.
     :param ignore_case: Boolean for whether or not to be case insensitive in the regular expression.
@@ -201,8 +202,8 @@ def abbr_to_fips(code: Union[str, Iterable],
     """Look up state FIPS codes by abbreviation with regular expression support.
 
     Given an individual or list of state abbreviations or regular expressions,
-    look up the corresponding state FIPS codes. The returned codes are 5 digits and
-    end with 000.
+    look up the corresponding state FIPS codes. The returned codes are 5 digits: the
+    2 digit state fips and 000 appeneded to the end.
 
     :param code: Individual or list of abbreviations or regular expressions.
     :param ignore_case: Boolean for whether or not to be case insensitive in the regular expression.

--- a/Python-packages/covidcast-py/covidcast/geography.py
+++ b/Python-packages/covidcast-py/covidcast/geography.py
@@ -203,7 +203,7 @@ def abbr_to_fips(code: Union[str, Iterable],
 
     Given an individual or list of state abbreviations or regular expressions,
     look up the corresponding state FIPS codes. The returned codes are 5 digits: the
-    2 digit state fips and 000 appeneded to the end.
+    2 digit state FIPS with 000 appended to the end.
 
     :param code: Individual or list of abbreviations or regular expressions.
     :param ignore_case: Boolean for whether or not to be case insensitive in the regular expression.

--- a/Python-packages/covidcast-py/docs/signals.rst
+++ b/Python-packages/covidcast-py/docs/signals.rst
@@ -61,3 +61,7 @@ States
 .. autofunction:: covidcast.abbr_to_name
 
 .. autofunction:: covidcast.name_to_abbr
+
+.. autofunction:: covidcast.abbr_to_fips
+
+.. autofunction:: covidcast.fips_to_abbr

--- a/Python-packages/covidcast-py/tests/covidcast/test_geography.py
+++ b/Python-packages/covidcast-py/tests/covidcast/test_geography.py
@@ -120,6 +120,32 @@ def test_name_to_abbr(test_key, test_kwargs, expected):
 
 @pytest.mark.parametrize("test_key, test_kwargs, expected", [
     (
+            "12",
+            {},
+            ["FL"]
+    ),
+    (
+            "7",
+            {"ties_method": "all"},
+            [{'17000': ['IL'],
+              '27000': ['MN'],
+              '37000': ['NC'],
+              '47000': ['TN'],
+              '72000': ['PR']}]
+
+    ),
+    (
+            ["ABC"],
+            {},
+            [None]
+    ),
+])
+def test_fips_to_abbr(test_key, test_kwargs, expected):
+    assert geography.fips_to_abbr(test_key, **test_kwargs) == expected
+
+
+@pytest.mark.parametrize("test_key, test_kwargs, expected", [
+    (
             "Pittsburgh",
             {},
             ["38300"]
@@ -137,6 +163,27 @@ def test_name_to_abbr(test_key, test_kwargs, expected):
 ])
 def test_name_to_cbsa(test_key, test_kwargs, expected):
     assert geography.name_to_cbsa(test_key, **test_kwargs) == expected
+
+
+@pytest.mark.parametrize("test_key, test_kwargs, expected", [
+    (
+            "PA",
+            {},
+            ["42000"]
+    ),
+    (
+            "New",
+            {},
+            [None]
+    ),
+    (
+            ["PA", "ca"],
+            {"ignore_case": True},
+            ["42000", "06000"]
+    )
+])
+def test_abbr_to_fips(test_key, test_kwargs, expected):
+    assert geography.abbr_to_fips(test_key, **test_kwargs) == expected
 
 
 @pytest.mark.parametrize("test_key, test_kwargs, expected", [
@@ -317,6 +364,7 @@ def test__lookup(test_args, test_kwargs, expected):
             None
     )
 ])
+
 def test__get_first_tie(test_dict_list, expected_return, warn, expected_warning):
     if warn:
         with pytest.warns(UserWarning) as record:
@@ -324,4 +372,3 @@ def test__get_first_tie(test_dict_list, expected_return, warn, expected_warning)
             assert record[0].message.args[0] == expected_warning
     else:
         assert geography._get_first_tie(test_dict_list) == expected_return
-


### PR DESCRIPTION
Closes #137 
Summary of changes:


* Add fips to abbr function and abbr to fips function, which requires doing basic string manipulation on the mapping file.
* update documentation



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1198968030437421/1198970435180742) by [Unito](https://www.unito.io/learn-more)
