### PR TITLE
Add custom warning to be more informative when getting data

### DIFF
--- a/Python-packages/covidcast-py/covidcast/covidcast.py
+++ b/Python-packages/covidcast-py/covidcast/covidcast.py
@@ -374,8 +374,6 @@ def _fetch_single_geo(data_source: str,
                                      issues=issues_strs, lag=lag)
 
         # Two possible error conditions: no data or too much data.
-        print(day_data)
-        print(data_source)
         if day_data["message"] == "no results":
             warnings.warn(f"No {data_source} {signal} data found on {day_str} "
                           f"for geography '{geo_type}'",

--- a/Python-packages/covidcast-py/covidcast/covidcast.py
+++ b/Python-packages/covidcast-py/covidcast/covidcast.py
@@ -374,13 +374,16 @@ def _fetch_single_geo(data_source: str,
                                      issues=issues_strs, lag=lag)
 
         # Two possible error conditions: no data or too much data.
+        print(day_data)
+        print(data_source)
         if day_data["message"] == "no results":
             warnings.warn(f"No {data_source} {signal} data found on {day_str} "
                           f"for geography '{geo_type}'",
                           NoDataWarning)
         if day_data["message"] not in {"success", "no results"}:
             warnings.warn(f"Problem obtaining {data_source} {signal} data on {day_str} "
-                          f"for geography '{geo_type}': {day_data['message']}")
+                          f"for geography '{geo_type}': {day_data['message']}",
+                          RuntimeWarning)
 
         # In the too-much-data case, we continue to try putting the truncated
         # data in our results. In the no-data case, skip this day entirely,

--- a/Python-packages/covidcast-py/covidcast/covidcast.py
+++ b/Python-packages/covidcast-py/covidcast/covidcast.py
@@ -7,6 +7,8 @@ from functools import reduce
 import pandas as pd
 from delphi_epidata import Epidata
 
+from .errors import NoDataWarning
+
 # Point API requests to the AWS endpoint
 Epidata.BASE_URL = "https://api.covidcast.cmu.edu/epidata/api.php"
 
@@ -372,10 +374,13 @@ def _fetch_single_geo(data_source: str,
                                      issues=issues_strs, lag=lag)
 
         # Two possible error conditions: no data or too much data.
-        if day_data["message"] != "success":
-            warnings.warn("Problem obtaining data on {day}: {message}".format(
-                day=day_str,
-                message=day_data["message"]))
+        if day_data["message"] == "no results":
+            warnings.warn(f"No {data_source} {signal} data found on {day_str} "
+                          f"for geography '{geo_type}'",
+                          NoDataWarning)
+        if day_data["message"] not in {"success", "no results"}:
+            warnings.warn(f"Problem obtaining {data_source} {signal} data on {day_str} "
+                          f"for geography '{geo_type}': {day_data['message']}")
 
         # In the too-much-data case, we continue to try putting the truncated
         # data in our results. In the no-data case, skip this day entirely,

--- a/Python-packages/covidcast-py/covidcast/errors.py
+++ b/Python-packages/covidcast-py/covidcast/errors.py
@@ -1,0 +1,5 @@
+"""Custom warnings and exceptions for covidcast functions."""
+
+
+class NoDataWarning(Warning):
+    """Warning raised when no data is returned on a given day by covidcast.signal()."""

--- a/Python-packages/covidcast-py/tests/covidcast/test_covidcast.py
+++ b/Python-packages/covidcast-py/tests/covidcast/test_covidcast.py
@@ -235,7 +235,7 @@ def test__fetch_single_geo(mock_covidcast):
 
     # test warning when a no data response is received
     with warnings.catch_warnings(record=True) as w:
-        covidcast._fetch_single_geo("source", "signal", date(2020, 4, 2), date(2020, 4, 4),
+        covidcast._fetch_single_geo("source", "signal", date(2020, 4, 2), date(2020, 4, 2),
                                     "county", None, None, None, None)
         assert len(w) == 1
         assert str(w[0].message) == "No source signal data found on 20200402 for geography 'county'"

--- a/Python-packages/covidcast-py/tests/covidcast/test_covidcast.py
+++ b/Python-packages/covidcast-py/tests/covidcast/test_covidcast.py
@@ -207,8 +207,8 @@ def test__fetch_single_geo(mock_covidcast):
                                    "epidata": [{"time_value": 20200821,
                                                 "issue": 20200925}],
                                    "message": "success"},
-                                  {"message": "failed"},  # unsuccessful API response
-                                  {"message": "no results"},  # unsuccessful API response
+                                  {"message": "failed"},  # unknown failed API response
+                                  {"message": "no results"},  # no data API response
                                   {"message": "success"},  # no epidata
                                   {"message": "success"}]
 
@@ -224,7 +224,7 @@ def test__fetch_single_geo(mock_covidcast):
                             index=[0, 0])
     assert sort_df(response).equals(sort_df(expected))
 
-    # test warnings
+    # test warning when an unknown bad response is received
     with warnings.catch_warnings(record=True) as w:
         covidcast._fetch_single_geo("source", "signal", date(2020, 4, 2), date(2020, 4, 2),
                                     "*", None, None, None, None)
@@ -233,8 +233,9 @@ def test__fetch_single_geo(mock_covidcast):
                "Problem obtaining source signal data on 20200402 for geography '*': failed"
         assert w[0].category is RuntimeWarning
 
+    # test warning when a no data response is received
     with warnings.catch_warnings(record=True) as w:
-        covidcast._fetch_single_geo("source", "signal", date(2020, 4, 2), date(2020, 4, 2),
+        covidcast._fetch_single_geo("source", "signal", date(2020, 4, 2), date(2020, 4, 4),
                                     "county", None, None, None, None)
         assert len(w) == 1
         assert str(w[0].message) == "No source signal data found on 20200402 for geography 'county'"

--- a/Python-packages/covidcast-py/tests/covidcast/test_covidcast.py
+++ b/Python-packages/covidcast-py/tests/covidcast/test_covidcast.py
@@ -242,7 +242,7 @@ def test__fetch_single_geo(mock_covidcast):
         assert w[0].category is NoDataWarning
 
     # test no epidata yields nothing
-    assert not covidcast._fetch_single_geo('a', None, date(2020, 4, 1), date(2020, 4, 1),
+    assert not covidcast._fetch_single_geo(None, None, date(2020, 4, 1), date(2020, 4, 1),
                                            None, None, None, None, None)
 
     # test end_day < start_day yields nothing


### PR DESCRIPTION
Closes #139 

Summary of changes:
- Implement NoDataWarning custom warning for when no results are returned
- Change any other warnings to runtime warnings and raise them separately
- Add tests, and also fix two previous tests that weren't testing the right thing (oops)
