### PR TITLE
Add CI for R package

### DIFF
--- a/.github/workflows/r_ci.yml
+++ b/.github/workflows/r_ci.yml
@@ -39,5 +39,5 @@ jobs:
         shell: Rscript {0}
       - name: Check
         run: |
-          rcmdcheck::rcmdcheck(args = c("--no-manual", "--ignore-vignettes"), build_args = c("--no-build-vignettes"), error_on = "error")
+          rcmdcheck::rcmdcheck(args = c("--no-manual", "--ignore-vignettes", "--as-cran"), build_args = c("--no-build-vignettes"), error_on = "error")
         shell: Rscript {0}

--- a/.github/workflows/r_ci.yml
+++ b/.github/workflows/r_ci.yml
@@ -34,7 +34,7 @@ jobs:
         run: sudo apt-get install libcurl4-openssl-dev
       - name: Install dependencies
         run: |
-          install.packages(c("remotes", "rcmdcheck"))
+          install.packages(c("remotes", "rcmdcheck", "devtools"))
           remotes::install_deps(dependencies = TRUE)
         shell: Rscript {0}
       - name: Check

--- a/.github/workflows/r_ci.yml
+++ b/.github/workflows/r_ci.yml
@@ -32,11 +32,24 @@ jobs:
           r-version: ${{ matrix.r-version }}
       - name: Install libcurl
         run: sudo apt-get install libcurl4-openssl-dev
-      - name: Install dependencies
+      - name: Query dependencies
         run: |
-          install.packages(c("remotes", "rcmdcheck"))
-          remotes::install_deps(dependencies = TRUE)
+          install.packages('remotes')
+          saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
+          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
         shell: Rscript {0}
+      - name: Cache R packages
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.R_LIBS_USER }}
+          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
+          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
+      - name: Install system dependencies
+        run: |
+          while read -r cmd
+          do
+            eval sudo $cmd
+          done < <(Rscript -e 'writeLines(remotes::system_requirements("ubuntu", "20.04"))')
       - name: Check
         run: |
           rcmdcheck::rcmdcheck(args = c("--no-manual", "--ignore-vignettes", "--as-cran"), build_args = c("--no-build-vignettes"), error_on = "error")

--- a/.github/workflows/r_ci.yml
+++ b/.github/workflows/r_ci.yml
@@ -39,5 +39,5 @@ jobs:
         shell: Rscript {0}
       - name: Check
         run: |
-          rcmdcheck::rcmdcheck(args = c("--no-manual, --no-vignettes"), error_on = "error")
+          rcmdcheck::rcmdcheck(args = c("--no-manual, --no-vignettes, --no-build-vignettes, --ignore-vignette"), error_on = "error")
         shell: Rscript {0}

--- a/.github/workflows/r_ci.yml
+++ b/.github/workflows/r_ci.yml
@@ -34,11 +34,10 @@ jobs:
         run: sudo apt-get install libcurl4-openssl-dev
       - name: Install dependencies
         run: |
-          install.packages(c("remotes", "rcmdcheck", "devtools"))
+          install.packages(c("remotes", "rcmdcheck"))
           remotes::install_deps(dependencies = TRUE)
         shell: Rscript {0}
       - name: Check
         run: |
-          devtools::check(vignettes=FALSE)
           rcmdcheck::rcmdcheck(args = c("--no-manual, --no-vignettes"), error_on = "error")
         shell: Rscript {0}

--- a/.github/workflows/r_ci.yml
+++ b/.github/workflows/r_ci.yml
@@ -39,5 +39,5 @@ jobs:
         shell: Rscript {0}
       - name: Check
         run: |
-          rcmdcheck::rcmdcheck(args = c("--no-manual, --no-vignettes, --no-build-vignettes, --ignore-vignette"), error_on = "error")
+          rcmdcheck::rcmdcheck(args = c("--no-manual", "--ignore-vignettes"), build_args = c("--no-build-vignettes"), error_on = "error")
         shell: Rscript {0}

--- a/.github/workflows/r_ci.yml
+++ b/.github/workflows/r_ci.yml
@@ -1,0 +1,42 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+#
+# See https://github.com/r-lib/actions/tree/master/examples#readme for
+# additional example workflows available for the R community.
+
+name: R
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: R-packages/covidcast/
+    strategy:
+      matrix:
+        r-version: [3.5]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up R ${{ matrix.r-version }}
+        uses: r-lib/actions/setup-r@ffe45a39586f073cc2e9af79c4ba563b657dc6e3
+        with:
+          r-version: ${{ matrix.r-version }}
+      - name: Install dependencies
+        run: |
+          install.packages(c("remotes", "rcmdcheck"))
+          remotes::install_deps(dependencies = TRUE)
+        shell: Rscript {0}
+      - name: Check
+        run: |
+          devtools::check(vignettes=FALSE)
+          rcmdcheck::rcmdcheck(args = c("--no-manual, --no-vignettes"), error_on = "error")
+        shell: Rscript {0}

--- a/.github/workflows/r_ci.yml
+++ b/.github/workflows/r_ci.yml
@@ -26,6 +26,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - name: Set up R ${{ matrix.r-version }}
+        uses: r-lib/actions/setup-r@ffe45a39586f073cc2e9af79c4ba563b657dc6e3
+        with:
+          r-version: ${{ matrix.r-version }}
       - name: Install libcurl
         run: sudo apt-get install libcurl4-openssl-dev
       - name: Install dependencies

--- a/.github/workflows/r_ci.yml
+++ b/.github/workflows/r_ci.yml
@@ -30,6 +30,8 @@ jobs:
         uses: r-lib/actions/setup-r@ffe45a39586f073cc2e9af79c4ba563b657dc6e3
         with:
           r-version: ${{ matrix.r-version }}
+      - name: Install libcurl
+        run: sudo apt-get install libcurl4-openssl-dev
       - name: Install dependencies
         run: |
           install.packages(c("remotes", "rcmdcheck"))

--- a/.github/workflows/r_ci.yml
+++ b/.github/workflows/r_ci.yml
@@ -35,7 +35,7 @@ jobs:
         run: sudo apt-get install libcurl4-openssl-dev
       - name: Query dependencies
         run: |
-          install.packages('remotes')
+          install.packages(c("remotes", "rcmdcheck"))
           saveRDS(remotes::dev_package_deps(dependencies = TRUE), "../../.github/depends.Rds", version = 2)
           writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), "../../.github/R-version")
         shell: Rscript {0}

--- a/.github/workflows/r_ci.yml
+++ b/.github/workflows/r_ci.yml
@@ -24,12 +24,17 @@ jobs:
       matrix:
         r-version: [3.5]
 
+    env:
+      R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
+      RSPM: ${{ matrix.config.rspm }}
+
     steps:
       - uses: actions/checkout@v2
-      - name: Set up R ${{ matrix.r-version }}
-        uses: r-lib/actions/setup-r@ffe45a39586f073cc2e9af79c4ba563b657dc6e3
-        with:
-          r-version: ${{ matrix.r-version }}
+
+      - uses: r-lib/actions/setup-r@master
+
+      - uses: r-lib/actions/setup-pandoc@master
+
       - name: Install libcurl
         run: sudo apt-get install libcurl4-openssl-dev
       - name: Query dependencies

--- a/.github/workflows/r_ci.yml
+++ b/.github/workflows/r_ci.yml
@@ -32,16 +32,16 @@ jobs:
           r-version: ${{ matrix.r-version }}
       - name: Install libcurl
         run: sudo apt-get install libcurl4-openssl-dev
-      - name: Install dependencies
-        run: |
-          install.packages(c("remotes", "rcmdcheck"))
-          remotes::install_deps(dependencies = TRUE)
-        shell: Rscript {0}
       - name: Cache R packages
         uses: actions/cache@v2
         with:
           path: ${{ env.R_LIBS_USER }}
           key: ${{ runner.os }}-r-1-
+      - name: Install dependencies
+        run: |
+          install.packages(c("remotes", "rcmdcheck"))
+          remotes::install_deps(dependencies = TRUE)
+        shell: Rscript {0}
       - name: Check
         run: |
           rcmdcheck::rcmdcheck(args = c("--no-manual", "--ignore-vignettes", "--as-cran"), build_args = c("--no-build-vignettes"), error_on = "error")

--- a/.github/workflows/r_ci.yml
+++ b/.github/workflows/r_ci.yml
@@ -27,30 +27,18 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: r-lib/actions/setup-r@master
-      - name: Set up R ${{ matrix.r-version }}
-        uses: r-lib/actions/setup-r@ffe45a39586f073cc2e9af79c4ba563b657dc6e3
-        with:
-          r-version: ${{ matrix.r-version }}
       - name: Install libcurl
         run: sudo apt-get install libcurl4-openssl-dev
-      - name: Query dependencies
+      - name: Install dependencies
         run: |
           install.packages(c("remotes", "rcmdcheck"))
-          saveRDS(remotes::dev_package_deps(dependencies = TRUE), "../../.github/depends.Rds", version = 2)
-          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), "../../.github/R-version")
+          remotes::install_deps(dependencies = TRUE)
         shell: Rscript {0}
       - name: Cache R packages
         uses: actions/cache@v2
         with:
           path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-${{ hashFiles('../../.github/R-version') }}-1-${{ hashFiles('../../.github/depends.Rds') }}
-          restore-keys: ${{ runner.os }}-${{ hashFiles('../../.github/R-version') }}-1-
-      - name: Install system dependencies
-        run: |
-          while read -r cmd
-          do
-            eval sudo $cmd
-          done < <(Rscript -e 'writeLines(remotes::system_requirements("ubuntu", "20.04"))')
+          key: ${{ runner.os }}-${{ hashFiles('../../.github/R-version') }}-1-
       - name: Check
         run: |
           rcmdcheck::rcmdcheck(args = c("--no-manual", "--ignore-vignettes", "--as-cran"), build_args = c("--no-build-vignettes"), error_on = "error")

--- a/.github/workflows/r_ci.yml
+++ b/.github/workflows/r_ci.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-${{ hashFiles('../../.github/R-version') }}-1-
+          key: ${{ runner.os }}-r-1-
       - name: Check
         run: |
           rcmdcheck::rcmdcheck(args = c("--no-manual", "--ignore-vignettes", "--as-cran"), build_args = c("--no-build-vignettes"), error_on = "error")

--- a/.github/workflows/r_ci.yml
+++ b/.github/workflows/r_ci.yml
@@ -26,6 +26,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - uses: r-lib/actions/setup-r@master
       - name: Set up R ${{ matrix.r-version }}
         uses: r-lib/actions/setup-r@ffe45a39586f073cc2e9af79c4ba563b657dc6e3
         with:

--- a/.github/workflows/r_ci.yml
+++ b/.github/workflows/r_ci.yml
@@ -24,31 +24,26 @@ jobs:
       matrix:
         r-version: [3.5]
 
-    env:
-      R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
-      RSPM: ${{ matrix.config.rspm }}
-
     steps:
       - uses: actions/checkout@v2
-
-      - uses: r-lib/actions/setup-r@master
-
-      - uses: r-lib/actions/setup-pandoc@master
-
+      - name: Set up R ${{ matrix.r-version }}
+        uses: r-lib/actions/setup-r@ffe45a39586f073cc2e9af79c4ba563b657dc6e3
+        with:
+          r-version: ${{ matrix.r-version }}
       - name: Install libcurl
         run: sudo apt-get install libcurl4-openssl-dev
       - name: Query dependencies
         run: |
           install.packages('remotes')
-          saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
-          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
+          saveRDS(remotes::dev_package_deps(dependencies = TRUE), "../../.github/depends.Rds", version = 2)
+          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), "../../.github/R-version")
         shell: Rscript {0}
       - name: Cache R packages
         uses: actions/cache@v2
         with:
           path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
-          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
+          key: ${{ runner.os }}-${{ hashFiles('../../.github/R-version') }}-1-${{ hashFiles('../../.github/depends.Rds') }}
+          restore-keys: ${{ runner.os }}-${{ hashFiles('../../.github/R-version') }}-1-
       - name: Install system dependencies
         run: |
           while read -r cmd

--- a/.github/workflows/r_ci.yml
+++ b/.github/workflows/r_ci.yml
@@ -26,7 +26,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: r-lib/actions/setup-r@master
       - name: Install libcurl
         run: sudo apt-get install libcurl4-openssl-dev
       - name: Install dependencies


### PR DESCRIPTION
Closes #142

Summary of Changes:


* Add CI for R `covidcast` package (no evalcast yet)

Notes


* The check currently only fails if there are errors, and will not fail on warnings. There is currently one warning in the code.
* The CI config was pulled from the github actions premade template, which was mostly taken from the [r-lib](https://github.com/r-lib/actions/tree/master/examples#quickstart-ci-workflow) repo. I've changed it to not build vignettes, run on just one version of R, and on linux instead of mac (which is 10x cheaper).
* [RESOLVED by caching dependencies] It takes 6 minutes to install dependencies, which is quite a long time, and the check itself is <1min. I'm not sure if this can be optimized. That amount of time is a bit annoying to merge things fast and also drives up [compute minutes (and costs once we use up the free tier)](https://docs.github.com/en/free-pro-team@latest/github/setting-up-and-managing-billing-and-payments-on-github/about-billing-for-github-actions) by almost an order of magnitude. I don't know how close we are to using up all the free CI time, but this would certainly add up. It shouldn't be hugely expensive if we do start paying (see pricing in the previous link), but still worth calling out.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1198968030437421/1198970431945681) by [Unito](https://www.unito.io/learn-more)
