### PR TITLE
Reorder Python requirements in makefile

### DIFF
--- a/Python-packages/covidcast-py/Makefile
+++ b/Python-packages/covidcast-py/Makefile
@@ -1,8 +1,8 @@
 .PHONY = lint, test, install-requirements, build-and-install
 
 install-requirements:
-	pip install -r requirements_ci.txt
 	pip install -r requirements_dev.txt
+	pip install -r requirements_ci.txt
 
 build-and-install: install-requirements
 	python3 setup.py clean

--- a/Python-packages/covidcast-py/requirements_dev.txt
+++ b/Python-packages/covidcast-py/requirements_dev.txt
@@ -1,3 +1,3 @@
+wheel
 sphinx
 sphinx-autodoc-typehints
-wheel


### PR DESCRIPTION
Summary of changes:
- Have dev requirements install before package dependencies. 

I can't reproduce this anymore, but one time I had a warning or error thrown when installing dependencies because wheel wasn't installed. Kinda weird but this should solve it.