### PR TITLE
Evalcast tests

### DIFF
--- a/R-packages/evalcast/R/get_predictions.R
+++ b/R-packages/evalcast/R/get_predictions.R
@@ -88,7 +88,7 @@ get_predictions_single_date <- function(forecaster,
                                         geo_type,
                                         geo_values,
                                         ...) {
-  if (length(geo_values) > 1) geo_values <- list(geo_values)
+  #if (length(geo_values) > 1) geo_values <- list(geo_values)
   forecast_date <- lubridate::ymd(forecast_date)
   # compute the start_day from the forecast_date, if we need to
   if (!is.null(signals$start_day) && is.list(signals$start_day)) {

--- a/R-packages/evalcast/tests/testthat/test-basic-functionality-runs-without-error.R
+++ b/R-packages/evalcast/tests/testthat/test-basic-functionality-runs-without-error.R
@@ -4,7 +4,10 @@ signals <- tibble(data_source = "jhu-csse",
                   signal = c("deaths_incidence_num", "confirmed_incidence_num"),
                   start_day = "2020-06-15")
 forecast_dates <- ymd(c("2020-07-20", "2020-08-10"))
+
 test_that("get_predictions and evaluate_predictions on baseline_forecaster works", {
+  # in addition to making sure these functions run, we will also use
+  # the generated pc and sc in other tests.
   pc <<- get_predictions(baseline_forecaster,
                          name_of_forecaster = "baseline",
                          signals = signals,
@@ -29,4 +32,40 @@ test_that("backfill_buffer works", {
                "backfill_buffer")
   # waited long enough:
   evaluate_predictions(pc, backfill_buffer = days_elapsed - 1)
+})
+
+test_that("get_predictions works when forecaster has additional arguments", {
+  forecaster_with_args <- function(df,
+                                   forecast_date,
+                                   signals,
+                                   incidence_period,
+                                   ahead,
+                                   geo_type,
+                                   symmetrize = TRUE,
+                                   arg1,
+                                   arg2) {
+    # this forecaster adds arg1 * arg2 to the predictions of the baseline 
+    # forecaster
+    out <- baseline_forecaster(df = df,
+                               forecast_date = forecast_date,
+                               signals = signals,
+                               incidence_period = incidence_period,
+                               ahead = ahead,
+                               geo_type = geo_type,
+                               symmetrize = symmetrize)
+    out$quantiles <- out$quantiles + arg1 * arg2
+    out
+  }
+  pc2 <- get_predictions(forecaster_with_args,
+                         name_of_forecaster = "forecaster_with_args",
+                         signals = signals,
+                         forecast_dates = forecast_dates,
+                         incidence_period = "epiweek",
+                         ahead = 3,
+                         geo_type = "state",
+                         arg1 = 2,
+                         arg2 = 5)
+  baseline_pred <- pc[[1]]$forecast_distribution[[1]]$quantiles
+  with_args_pred <- pc2[[1]]$forecast_distribution[[1]]$quantiles
+  expect_equal(baseline_pred + 10, with_args_pred)
 })

--- a/R-packages/evalcast/tests/testthat/test-basic-functionality-runs-without-error.R
+++ b/R-packages/evalcast/tests/testthat/test-basic-functionality-runs-without-error.R
@@ -1,24 +1,32 @@
 library(tibble)
 library(lubridate)
-library(covidcast)
 signals <- tibble(data_source = "jhu-csse",
-       signal = c("deaths_incidence_num", "confirmed_incidence_num"),
-       start_day = "2020-06-15")
+                  signal = c("deaths_incidence_num", "confirmed_incidence_num"),
+                  start_day = "2020-06-15")
 forecast_dates <- ymd(c("2020-07-20", "2020-08-10"))
 test_that("get_predictions and evaluate_predictions on baseline_forecaster works", {
-  predictions_cards <- get_predictions(baseline_forecaster,
-                                       name_of_forecaster = "baseline",
-                                       signals = signals,
-                                       forecast_dates = forecast_dates,
-                                       incidence_period = "epiweek",
-                                       ahead = 3,
-                                       geo_type = "state")
-  expect_equal(length(predictions_cards), 2)
+  pc <<- get_predictions(baseline_forecaster,
+                         name_of_forecaster = "baseline",
+                         signals = signals,
+                         forecast_dates = forecast_dates,
+                         incidence_period = "epiweek",
+                         ahead = 3,
+                         geo_type = "state")
+  expect_equal(length(pc), 2)
   err_measures <- list(wis = weighted_interval_score,
                        ae = absolute_error,
                        coverage_80 = interval_coverage(alpha = 0.2))
-  scorecards <- evaluate_predictions(filter_predictions(predictions_cards,
-                                                        ahead = 3),
-                                     err_measures,
-                                     backfill_buffer = 10)
+  sc <<- evaluate_predictions(filter_predictions(pc, ahead = 3),
+                              err_measures,
+                              backfill_buffer = 10)
+})
+
+test_that("backfill_buffer works", {
+  # how long has it been since the last target period ends in the scorecards?
+  days_elapsed <- sc %>% map_dbl(~ today() - max(.x$end)) %>% unlist()
+  # too soon:
+  expect_error(evaluate_predictions(pc, backfill_buffer = days_elapsed),
+               "backfill_buffer")
+  # waited long enough:
+  evaluate_predictions(pc, backfill_buffer = days_elapsed - 1)
 })

--- a/R-packages/evalcast/tests/testthat/test-basic-functionality-runs-without-error.R
+++ b/R-packages/evalcast/tests/testthat/test-basic-functionality-runs-without-error.R
@@ -4,24 +4,28 @@ signals <- tibble(data_source = "jhu-csse",
                   signal = c("deaths_incidence_num", "confirmed_incidence_num"),
                   start_day = "2020-06-15")
 forecast_dates <- ymd(c("2020-07-20", "2020-08-10"))
+common_objects <- new.env(parent = emptyenv())
 
 test_that("get_predictions and evaluate_predictions on baseline_forecaster works", {
   # in addition to making sure these functions run, we will also use
   # the generated pc and sc in other tests.
-  pc <<- get_predictions(baseline_forecaster,
-                         name_of_forecaster = "baseline",
-                         signals = signals,
-                         forecast_dates = forecast_dates,
-                         incidence_period = "epiweek",
-                         ahead = 3,
-                         geo_type = "state")
+  pc <- get_predictions(baseline_forecaster,
+                        name_of_forecaster = "baseline",
+                        signals = signals,
+                        forecast_dates = forecast_dates,
+                        incidence_period = "epiweek",
+                        ahead = 3,
+                        geo_type = "state")
   expect_equal(length(pc), 2)
   err_measures <- list(wis = weighted_interval_score,
                        ae = absolute_error,
                        coverage_80 = interval_coverage(alpha = 0.2))
-  sc <<- evaluate_predictions(filter_predictions(pc, ahead = 3),
-                              err_measures,
-                              backfill_buffer = 10)
+  sc <- evaluate_predictions(filter_predictions(pc, ahead = 3),
+                             err_measures,
+                             backfill_buffer = 10)
+  # let's save these for other tests:
+  common_objects$pc <- pc
+  common_objects$sc <- sc
 })
 
 test_that("geo_values argument to get_predictions works", {
@@ -36,18 +40,21 @@ test_that("geo_values argument to get_predictions works", {
                          ahead = 3,
                          geo_type = "state",
                          geo_values = geo_values)
-  both <- pc2[[1]] %>% left_join(pc[[1]], by = "location")
+  both <- pc2[[1]] %>% left_join(common_objects$pc[[1]], by = "location")
   expect_identical(both$forecast_distribution.x, both$forecast_distribution.y)
 })
 
 test_that("backfill_buffer works", {
   # how long has it been since the last target period ends in the scorecards?
-  days_elapsed <- sc %>% map_dbl(~ today() - max(.x$end)) %>% unlist()
+  days_elapsed <- common_objects$sc %>%
+    map_dbl(~ today() - max(.x$end)) %>% 
+    unlist()
   # too soon should give error:
-  expect_error(evaluate_predictions(pc, backfill_buffer = days_elapsed),
+  expect_error(evaluate_predictions(common_objects$pc,
+                                    backfill_buffer = days_elapsed),
                "backfill_buffer")
   # waited long enough should have no error:
-  evaluate_predictions(pc, backfill_buffer = days_elapsed - 1)
+  evaluate_predictions(common_objects$pc, backfill_buffer = days_elapsed - 1)
 })
 
 test_that("get_predictions works when forecaster has additional arguments", {
@@ -81,7 +88,7 @@ test_that("get_predictions works when forecaster has additional arguments", {
                          geo_type = "state",
                          arg1 = 2,
                          arg2 = 5)
-  baseline_pred <- pc[[1]]$forecast_distribution[[1]]$quantiles
+  baseline_pred <- common_objects$pc[[1]]$forecast_distribution[[1]]$quantiles
   with_args_pred <- pc2[[1]]$forecast_distribution[[1]]$quantiles
   expect_equal(baseline_pred + 10, with_args_pred)
 })


### PR DESCRIPTION
Adding more tests to the evalcast package (and fixing a bug involving geo_values).  The new tests:
- test that backfill buffer works
- test that additional arguments to forecaster works
- test that geo_values works
- test that start_day within signals works

I've verified that all tests pass and R CMD check runs with no errors, warnings, or notes.