### PR TITLE
Memoize evalcast functions

### DIFF
--- a/R-packages/evalcast/R/package.R
+++ b/R-packages/evalcast/R/package.R
@@ -15,3 +15,15 @@
 #' @import readr
 #' @import stringr
 NULL
+
+.onLoad <- function(libname, pkgname) {
+    download_signal <<- memoise::memoise(download_signal)
+    get_covidhub_predictions <<- memoise::memoise(get_covidhub_predictions)
+    msg <- c("Calls to functions `download_signal()` and `get_covidhub_predictions()` are memoized",
+    "in memory by default.  To cache to disk instead use `memoise::cache_filesystem()`.  Ex:",
+    "",
+    "  db <- memoise::cache_filesystem(\"path/to/my/cache/dir/.rcache\")",
+    "  download_signal <<- memoise::memoise(download_signal, cache = db)",
+    "")
+    packageStartupMessage(paste(msg, collapse = "\n"))
+}


### PR DESCRIPTION
Fixes #218.  `download_signal()` and `get_covidhub_predictions()` are cached in memory.