### PR TITLE
Fix comma mismatch

### DIFF
--- a/R-packages/evalcast/R/plot_trajectory.R
+++ b/R-packages/evalcast/R/plot_trajectory.R
@@ -29,8 +29,8 @@ plot_trajectory <- function(list_of_predictions_cards,
                             last_day = Sys.Date(),
                             alpha = .2,
                             nrow = 6,
-                            ncol = 4,  
-                            page_facet = 1，
+                            ncol = 4,
+                            page_facet = 1,
                             cutoff = 52){
   # make sure predictions cards are for the same forecasting task (except ahead, and forecast_date)
   response <- unique_attr(list_of_predictions_cards,"signals")


### PR DESCRIPTION
One of arguments in `plot_trajectory()` had a trailing comma from a Chinese keyboard rather than the ASCII character.  This PR replaces it with the correct comma.