### PR TITLE
Propagate failures in dashboard generation so that a non-zero exit code is returned

### DIFF
--- a/R-notebooks/make.R
+++ b/R-notebooks/make.R
@@ -8,16 +8,21 @@ for (file_name in file_names) {
   t0 = proc.time()
   tryCatch(
     suppressWarnings(suppressMessages(
-      rmarkdown::render(paste0(file_name, ".Rmd"),  
-                        output_format="html_document",
-                        output_file=paste0(file_name, ".html"),
-                        envir=new.env(), quiet=TRUE))),
-    error = function(e) { 
-      cat(e$message) 
+      rmarkdown::render(
+        paste0(file_name, ".Rmd"),
+        output_format = "html_document",
+        output_file = paste0(file_name, ".html"),
+        envir = new.env(),
+        quiet = TRUE
+      )
+    )),
+    error = function(e) {
+      cat(e$message)
       has_failures <<- TRUE
-    })
+    }
+  )
   t1 = proc.time()
-  cat(sprintf("%0.2f s\n", (t1-t0)[3]))
+  cat(sprintf("%0.2f s\n", (t1 - t0)[3]))
 }
 
 # Failures do not prevent other dashboards from running, but should result in an

--- a/R-notebooks/make.R
+++ b/R-notebooks/make.R
@@ -1,6 +1,8 @@
 file_names = list.files(".", pattern="*.Rmd")
 file_names = substr(file_names, 1, nchar(file_names)-4)
 
+has_failures = FALSE
+
 for (file_name in file_names) {
   cat(sprintf("Rendering %s ... ", file_name))
   t0 = proc.time()
@@ -10,9 +12,17 @@ for (file_name in file_names) {
                         output_format="html_document",
                         output_file=paste0(file_name, ".html"),
                         envir=new.env(), quiet=TRUE))),
-    error = function(e) { cat(e$message) })
+    error = function(e) { 
+      cat(e$message) 
+      has_failures <<- TRUE
+    })
   t1 = proc.time()
   cat(sprintf("%0.2f s\n", (t1-t0)[3]))
 }
 
+# Failures do not prevent other dashboards from running, but should result in an
+# error status being set.
+if (has_failures) {
+  quit(status = 1)
+}
 


### PR DESCRIPTION
Fix for #257. Tracks and propagates errors in generating dashboards into a non-zero exit code on the script.