### PR TITLE
Add a CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,19 @@
+# default owners for anything not listed below, such as README and CI workflows
+* @krivard @capnrefsmmat @ryantibs
+
+# covidcast R package and data generation
+/R-packages/covidcast/ @capnrefsmmat @ryantibs @sgsmob
+/R-packages/data-raw/ @capnrefsmmat @ryantibs @sgsmob
+
+# evalcast R package
+/R-packages/evalcast/  @ryantibs @jacobbien
+
+# covidcast Python package
+/Python-packages/covidcast-py/ @chinandrew @capnrefsmmat
+
+# notebooks
+/R-notebooks/  @ryantibs @benjaminysmith
+
+# documentation changes go live instantly on GitHub.io, and hence require their
+# own review
+/docs/  @capnrefsmmat

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,7 @@
 /R-packages/data-raw/ @capnrefsmmat @ryantibs @sgsmob
 
 # evalcast R package
-/R-packages/evalcast/  @ryantibs @jacobbien
+/R-packages/evalcast/  @ryantibs @jacobbien @dajmcdon
 
 # covidcast Python package
 /Python-packages/covidcast-py/ @chinandrew @capnrefsmmat

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,7 +12,7 @@
 /Python-packages/covidcast-py/ @chinandrew @capnrefsmmat
 
 # notebooks
-/R-notebooks/  @ryantibs @benjaminysmith
+/R-notebooks/  @benjaminysmith @capolitsch @krivard 
 
 # documentation changes go live instantly on GitHub.io, and hence require their
 # own review


### PR DESCRIPTION
This is a draft. I just threw this together so we could get some concrete discussion going; I expect we'll make a bunch of changes to it.

The syntax is like `.gitignore` with a filename pattern, then followed by a space-separated list of GitHub usernames.

When a pull request touches any of these directories, GitHub will require review from one of the listed owners before allowing the review to be merged. (I'll turn on branch protection so it'll be impossible to push directly to main.) The question is whether these lists of owners are complete, or if additional owners are required.

Note that owners will also be notified automatically for each PR touching their files.

- @dajmcdon Should you be listed for evalcast? Anyone else?
- @sgsmob I added you for the R package just because you've started reviewing my PRs for it; up to you
- @krivard Should you be listed on the notebooks, since you're running them daily?

cc @chinandrew, @jacobbien since they're also listed as owners of some things