### PR TITLE
Add S3 class typing to cards

### DIFF
--- a/R-packages/evalcast/R/evaluate.R
+++ b/R-packages/evalcast/R/evaluate.R
@@ -159,6 +159,7 @@ evaluate_predictions_single_ahead <- function(predictions_cards,
          backfill_buffer = backfill_buffer,
          as_of = as_of)
   )
+  class(score_card) <- c("score_card", class(score_card))
   return(score_card)
 }
 

--- a/R-packages/evalcast/R/get_covidhub_predictions.R
+++ b/R-packages/evalcast/R/get_covidhub_predictions.R
@@ -82,7 +82,7 @@ get_covidhub_predictions <- function(covid_hub_forecaster_name,
                geo_values = NA,
                from_covidhub = TRUE)
         )
-
+        class(.x) <- c("prediction_card", class(.x))
         return(.x)
       })
   }


### PR DESCRIPTION
Annotate an S3 class onto each tibble in the lists returned by `evalcast::get_covidhub_predictions()` and `evalcast::evaluate_predictions()` ("prediction_card" and "score_card", respectively). This will allow us to have generic methods for printing (#222) and aggregating (#221) the cards while allowing specialized behavior for the two types of cards.

See also #150.