### PR TITLE
Update main to have same ci config as r-pkg-devel

### DIFF
--- a/.github/workflows/python_ci.yml
+++ b/.github/workflows/python_ci.yml
@@ -5,9 +5,9 @@ name: Python Lint and Testing
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, r-pkg-devel ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, r-pkg-devel ]
 
 jobs:
   build:

--- a/.github/workflows/r_ci.yml
+++ b/.github/workflows/r_ci.yml
@@ -10,9 +10,9 @@ name: R
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, r-pkg-devel ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, r-pkg-devel ]
 
 jobs:
   build:
@@ -27,7 +27,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up R ${{ matrix.r-version }}
-        uses: r-lib/actions/setup-r@ffe45a39586f073cc2e9af79c4ba563b657dc6e3
+        uses: r-lib/actions/setup-r@v1
         with:
           r-version: ${{ matrix.r-version }}
       - name: Install libcurl
@@ -36,7 +36,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-r-1-
+          key: ${{ runner.os }}-r-2-
       - name: Install dependencies
         run: |
           install.packages(c("remotes", "rcmdcheck"))

--- a/R-packages/covidcast/tests/testthat/setup-options.R
+++ b/R-packages/covidcast/tests/testthat/setup-options.R
@@ -1,0 +1,6 @@
+# Many tests use hand-made reference data frames. In R < 4.0, columns like
+# `geo_values` and `data_source`, containing strings, are interpreted as
+# factors. To prevent us from having to set stringsAsFactors = FALSE in every
+# test case, set the option while saving the default to restore in the teardown
+# (in teardown-options.R).
+.defaultStringsAsFactors <- options(stringsAsFactors = FALSE)

--- a/R-packages/covidcast/tests/testthat/teardown-options.R
+++ b/R-packages/covidcast/tests/testthat/teardown-options.R
@@ -1,0 +1,2 @@
+# see setup-options.R
+options(stringsAsFactors = .defaultStringsAsFactors)


### PR DESCRIPTION
Some changes happened to tests are failing on main. They're fixed on r-pkg-devel and this fixes on main.