### PR TITLE
Dev date handle

### DIFF
--- a/R-packages/evalcast/R/get_covidhub_predictions.R
+++ b/R-packages/evalcast/R/get_covidhub_predictions.R
@@ -100,6 +100,7 @@ get_covidhub_predictions <- function(covid_hub_forecaster_name,
 #' @importFrom rvest html_nodes html_text
 #' @importFrom xml2 read_html
 #' @importFrom stringr str_remove_all str_match_all
+#' @importFrom lubridate as_date
 #' @export
 get_forecast_dates <- function(covid_hub_forecaster_name) {
   url <- "https://github.com/reichlab/covid19-forecast-hub/tree/master/data-processed/"
@@ -109,7 +110,7 @@ get_forecast_dates <- function(covid_hub_forecaster_name) {
     stringr::str_remove_all("\\n") %>%
     stringr::str_match_all(sprintf("(20\\d{2}-\\d{2}-\\d{2})-%s.csv",
                                    covid_hub_forecaster_name))
-  out[[1]][, 2]
+  return(as_date(out[[1]][, 2]))
 }
 
 #' @importFrom rvest html_nodes html_text

--- a/R-packages/evalcast/R/get_covidhub_predictions.R
+++ b/R-packages/evalcast/R/get_covidhub_predictions.R
@@ -110,7 +110,7 @@ get_forecast_dates <- function(covid_hub_forecaster_name) {
     stringr::str_remove_all("\\n") %>%
     stringr::str_match_all(sprintf("(20\\d{2}-\\d{2}-\\d{2})-%s.csv",
                                    covid_hub_forecaster_name))
-  return(as_date(out[[1]][, 2]))
+  return(lubridate::as_date(out[[1]][, 2]))
 }
 
 #' @importFrom rvest html_nodes html_text

--- a/R-packages/evalcast/vignettes/intro_vignette.Rmd
+++ b/R-packages/evalcast/vignettes/intro_vignette.Rmd
@@ -36,7 +36,7 @@ library(evalcast)
 library(covidcast)
 library(lubridate)
 
-forecast_dates <- as_date(get_forecast_dates("CMU-TimeSeries"))
+forecast_dates <- get_forecast_dates("CMU-TimeSeries")
 forecast_dates_july <- forecast_dates[forecast_dates >= "2020-07-01" & forecast_dates <= "2020-07-31"]
 
 # Retrieve past predictions from CovidHub


### PR DESCRIPTION
For consistency with covidcast and with function name, have `get_forecast_dates` return a date object instead of a character object. I was unable to reproduce the issue originally described in #153 but the consistency fix should resolve the issue, since it appears that evalcast functions have built in flexibility and are able to handle either date or character objects.