### PR TITLE
Fix Python client shapefile packaging

### DIFF
--- a/Python-packages/covidcast-py/setup.py
+++ b/Python-packages/covidcast-py/setup.py
@@ -31,5 +31,5 @@ setuptools.setup(
         "imageio",
         "tqdm"
     ],
-    package_data={"covidcast": ["shapefiles/*", "geo_mappings/*"]}
+    package_data={"covidcast": ["shapefiles/*/*", "geo_mappings/*"]}
 )


### PR DESCRIPTION
Summary of changes:
![a88](https://user-images.githubusercontent.com/20176218/99584482-dc701480-2999-11eb-8cde-083706c80a3c.jpg)

All the shapefiles are in subfolders, e.g. shapefiles/state/* or shapefiles/msa/*, so needed to add additional directory layer