### PR TITLE
R custom API endpoint

### DIFF
--- a/R-packages/covidcast/R/covidcast.R
+++ b/R-packages/covidcast/R/covidcast.R
@@ -667,9 +667,10 @@ covidcast <- function(data_source, signal, time_type, geo_type, time_values,
 
 # Helper function to request and parse epidata
 .request <- function(params) {
-  # API call
-  response <- httr::GET(COVIDCAST_BASE_URL, httr::user_agent("covidcastR"),
-                        query=params)
+  # API call. Allow base API URL to be replaced, e.g. to use a staging/testing
+  # server when needed.
+  response <- httr::GET(getOption("covidcast.base_url", default = COVIDCAST_BASE_URL),
+                        httr::user_agent("covidcastR"), query = params)
 
   httr::stop_for_status(response, task = "fetch data from API")
 


### PR DESCRIPTION
Fixes #317.

With this, you should be able to use `options(covidcast.base_url = "https://some-staging-server/...")` to have the package use a different endpoint.