### PR TITLE
Migrate `plot_trajectory()` onto `aggregate_cards()`

### DIFF
--- a/R-packages/evalcast/R/plot_trajectory.R
+++ b/R-packages/evalcast/R/plot_trajectory.R
@@ -204,12 +204,11 @@ get_target_period_num <- function(forecast_date,ahead,incidence_period){
   )
   if(incidence_period == "day")
   {
-    return(forecast_date + ahead)
+    forecast_date + ahead
   } else {
-    x = ifelse(wday(forecast_date) <= 2, 
+    ifelse(wday(forecast_date) <= 2, 
            MMWRweek::MMWRweek(forecast_date)$MMWRweek + ahead - 1,
            MMWRweek::MMWRweek(forecast_date)$MMWRweek + ahead)
-    return(x)
   }
 }
 

--- a/R-packages/evalcast/R/plot_trajectory.R
+++ b/R-packages/evalcast/R/plot_trajectory.R
@@ -50,18 +50,18 @@ plot_trajectory <- function(list_of_predictions_cards,
         abs(probs - plot_probs[1]) <= 1e-8 ~ "lower",
         abs(probs - plot_probs[2]) <= 1e-8 ~ "point",
         abs(probs - plot_probs[3]) <= 1e-8 ~ "upper")) %>%
-    filter(!is.na(.data$prob_type)) %>%
-    dplyr::mutate(target_period = get_target_period_num(.data$forecast_date,
-                                                        .data$ahead,
+    filter(!is.na(prob_type)) %>%
+    dplyr::mutate(target_period = get_target_period_num(forecast_date,
+                                                        ahead,
                                                         single_incidence_period),
-                  forecaster_name = .data$name_of_forecaster) %>%
-    dplyr::select(.data$location,
-                  .data$quantiles,
-                  .data$forecaster_name,
-                  .data$prob_type,
-                  .data$target_period,
-                  .data$forecast_date) %>%
-    tidyr::pivot_wider(values_from = .data$quantiles, names_from = .data$prob_type)
+                  forecaster_name = name_of_forecaster) %>%
+    dplyr::select(location,
+                  quantiles,
+                  forecaster_name,
+                  prob_type,
+                  target_period,
+                  forecast_date) %>%
+    tidyr::pivot_wider(values_from = quantiles, names_from = prob_type)
   
   # ground truth to plot
   if(single_incidence_period == "day") {
@@ -70,8 +70,8 @@ plot_trajectory <- function(list_of_predictions_cards,
                                    start_day = first_day,
                                    end_day = last_day,
                                    geo_type = geo_type) %>%
-      dplyr::select(.data$location, .data$time_value, .data$value) %>%
-      dplyr::rename(reference_period = .data$time_value) %>%
+      dplyr::select(ocation, time_value, value) %>%
+      dplyr::rename(reference_period = time_value) %>%
       dplyr::filter(location %in% preds_df$location) 
   } else {
     # avoid summing over partial epiweeks
@@ -90,7 +90,7 @@ plot_trajectory <- function(list_of_predictions_cards,
                                    start_day = sunday_following_first_day,
                                    end_day = saturday_preceding_last_day,
                                    geo_type = geo_type) %>%
-                   dplyr::select(location, .data$time_value,.data$value) %>%
+                   dplyr::select(location, time_value, value) %>%
                    sum_to_epiweek() %>%
                    dplyr::rename(reference_period = epiweek) %>%
                    dplyr::filter(location %in% preds_df$location)
@@ -125,18 +125,18 @@ plot_trajectory <- function(list_of_predictions_cards,
   
 
   # Framework of the trajectory plot
-  p <- ggplot(preds_df, aes(x = .data$reference_period)) +
-       geom_line(aes(y = .data$point,
-                     col = .data$forecaster_name, 
-                     group = .data$forecast_date),
+  p <- ggplot(preds_df, aes(x = reference_period)) +
+       geom_line(aes(y = point,
+                     col = forecaster_name, 
+                     group = forecast_date),
                      size = 1) + 
-       geom_point(aes(y = .data$point,
-                      col = .data$forecaster_name, 
-                      group = .data$forecast_date)) +
-       geom_ribbon(aes(ymin = .data$lower,
-                       ymax = .data$upper,
-                       fill = .data$forecaster_name,
-                       group = .data$forecast_date),
+       geom_point(aes(y = point,
+                      col = forecaster_name, 
+                      group = forecast_date)) +
+       geom_ribbon(aes(ymin = lower,
+                       ymax = upper,
+                       fill = forecaster_name,
+                       group = forecast_date),
                        alpha = .1,
                        colour = NA,
                        show.legend = FALSE) + 

--- a/R-packages/evalcast/R/plot_trajectory.R
+++ b/R-packages/evalcast/R/plot_trajectory.R
@@ -76,12 +76,17 @@ plot_trajectory <- function(list_of_predictions_cards,
   } else {
     # avoid summing over partial epiweeks
     date_range <- covidcast::covidcast_meta() %>% 
-      dplyr::filter(data_source == "usa-facts" & signal == response$signal & geo_type == !!geo_type) %>%
-      #dplyr::filter(data_source == response$data_source & signal == response$signal & geo_type == !!geo_type) %>%
+      dplyr::filter(data_source == "usa-facts" &
+                    signal == response$signal &
+                    geo_type == !!geo_type) %>%
       dplyr::select(min_time,max_time)
     
-    sunday_following_first_day <- shift_day_to_following_xxxday(max(ymd(date_range$min_time,first_day)),xxx = 1)
-    saturday_preceding_last_day <- shift_day_to_preceding_xxxday(min(ymd(date_range$max_time,last_day)),xxx = 7)
+    sunday_following_first_day <- shift_day_to_following_xxxday(
+                                    max(ymd(date_range$min_time,first_day)),
+                                    xxx = 1)
+    saturday_preceding_last_day <- shift_day_to_preceding_xxxday(
+                                    min(ymd(date_range$max_time,last_day)),
+                                    xxx = 7)
     assertthat::assert_that(sunday_following_first_day < saturday_preceding_last_day,
                             msg = "Pick first and last day to span at least one full epiweek.")
     
@@ -145,11 +150,11 @@ plot_trajectory <- function(list_of_predictions_cards,
                  size = 1) + 
        scale_color_discrete(na.translate = FALSE) +
        labs(x = single_incidence_period,
-            y = paste0(response$data_source,": ",response$signal),
+            y = paste0(response$data_source, ": ", response$signal),
             colour = "forecaster_name") +
        theme_bw() + 
        theme(axis.text = element_text(size = 8), 
-             strip.text = element_text(size = 10,face = "bold"))
+             strip.text = element_text(size = 10, face = "bold"))
   
  
   # Facetting. The default cutoff is 52, and plots that exceed 52 facets will be paginated.
@@ -177,27 +182,31 @@ sum_to_epiweek <- function(daily_df){
     ungroup()
 }
 
-shift_day_to_preceding_xxxday <- function(day,xxx){
+shift_day_to_preceding_xxxday <- function(day, xxx){
   ew_day <- MMWRweek::MMWRweek(day)
   if(ew_day$MMWRday < xxx)
   {
-    MMWRweek::MMWRweek2Date(MMWRyear = ew_day$MMWRyear, MMWRweek = ew_day$MMWRweek, MMWRday = xxx) - 7
+    MMWRweek::MMWRweek2Date(MMWRyear = ew_day$MMWRyear,
+                            MMWRweek = ew_day$MMWRweek,
+                            MMWRday = xxx) - 7
   } else {
     MMWRweek::MMWRweek2Date(MMWRyear = ew_day$MMWRyear, MMWRweek = ew_day$MMWRweek, MMWRday = xxx)
   }
 }
 
-shift_day_to_following_xxxday <- function(day,xxx){
+shift_day_to_following_xxxday <- function(day, xxx){
   ew_day <- MMWRweek::MMWRweek(day)
   if(ew_day$MMWRday > xxx)
   {
-    MMWRweek::MMWRweek2Date(MMWRyear = ew_day$MMWRyear, MMWRweek = ew_day$MMWRweek, MMWRday = xxx) + 7
+    MMWRweek::MMWRweek2Date(MMWRyear = ew_day$MMWRyear,
+                            MMWRweek = ew_day$MMWRweek,
+                            MMWRday = xxx) + 7
   } else {
     MMWRweek::MMWRweek2Date(MMWRyear = ew_day$MMWRyear, MMWRweek = ew_day$MMWRweek, MMWRday = xxx)
   }
 }
 
-get_target_period_num <- function(forecast_date,ahead,incidence_period){
+get_target_period_num <- function(forecast_date, ahead, incidence_period){
   assertthat::assert_that(
     incidence_period %in% c("day","epiweek"), 
     msg = "Incidence period must be one of day or epiweek."


### PR DESCRIPTION
The functionality of `aggregate_cards()` was modeled after a subset of `plot_trajectory()`.  To avoid code reuse, we replace the duplicated code in `plot_trajectory()` with a call to `aggregate_cards()`.

This PR also fixes a bug in `plot_trajectory()` where the `forecast_date` column was unavailable and cleans up some readability issues.