### PR TITLE
Fix error after R tests

### DIFF
--- a/R-packages/covidcast/tests/testthat/teardown-options.R
+++ b/R-packages/covidcast/tests/testthat/teardown-options.R
@@ -1,2 +1,2 @@
 # see setup-options.R
-options(stringsAsFactors = .defaultStringsAsFactors)
+options(.defaultStringsAsFactors)


### PR DESCRIPTION
.defaultStringsAsFactors is a list with one named element,
$stringsAsFactors, so we pass the entire list to options() to set that
option back to its default.

My fault when I introduced this trick in #290. It was causing this error message after tests completed:

```
Error in options(stringsAsFactors = .defaultStringsAsFactors) : 
  invalid value for 'stringsAsFactors'
```