### PR TITLE
Fix imports from dplyr and lubridate

### DIFF
--- a/R-packages/covidcast/DESCRIPTION
+++ b/R-packages/covidcast/DESCRIPTION
@@ -43,7 +43,6 @@ Imports:
   grDevices,
   httr,
   jsonlite,
-  lubridate,
   maptools,
   purrr,
   rlang,

--- a/R-packages/covidcast/R/covidcast.R
+++ b/R-packages/covidcast/R/covidcast.R
@@ -438,9 +438,9 @@ covidcast_meta <- function() {
   }
 
   meta <- meta$epidata %>%
-    dplyr::mutate(min_time = as.Date(as.character(.data$min_time), format = "%Y%m%d"),
-                  max_time = as.Date(as.character(.data$max_time), format = "%Y%m%d"),
-                  max_issue = as.Date(as.character(.data$max_issue), format = "%Y%m%d"))
+    dplyr::mutate(min_time = api_to_date(.data$min_time),
+                  max_time = api_to_date(.data$max_time),
+                  max_issue = api_to_date(.data$max_issue))
 
   class(meta) <- c("covidcast_meta", "data.frame")
   return(meta)
@@ -589,15 +589,18 @@ covidcast_days <- function(data_source, signal, start_day, end_day, geo_type,
     }
     if (dat[[i]]$message == "success") {
       desired_geos <- tolower(unique(geo_value))
+
       returned_epidata <- dat[[i]]$epidata
       returned_geo_array <- returned_epidata %>%
         dplyr::select(geo_value, time_value) %>%
         dplyr::group_by(time_value) %>%
         dplyr::summarize(geo_value = list(geo_value))
       returned_time_values <- returned_geo_array$time_value
+
       if (length(returned_time_values) != length(time_values)) {
         missing_time_values <- setdiff(time_values, returned_time_values)
-        missing_dates <- ymd(missing_time_values)
+        missing_dates <- api_to_date(missing_time_values)
+
         warn(sprintf("Data not fetched for the following days: %s",
                      paste(missing_dates, collapse = ", ")),
              data_source = data_source,
@@ -611,6 +614,7 @@ covidcast_days <- function(data_source, signal, start_day, end_day, geo_type,
       if (!identical("*", geo_value)) {
         missing_geo_array <- returned_geo_array[
           lapply(returned_geo_array$geo_value, length) < length(desired_geos), ]
+
         if (nrow(missing_geo_array) > 0) {
           missing_geo_array$warning <-
             unlist(apply(returned_geo_array,
@@ -620,7 +624,7 @@ covidcast_days <- function(data_source, signal, start_day, end_day, geo_type,
           warn(missing_geo_array$warning,
                data_source = data_source,
                signal = signal,
-               day = ymd(missing_geo_array$time_value),
+               day = api_to_date(missing_geo_array$time_value),
                geo_value = geo_value,
                api_msg = dat[[i]]$message,
                class = "covidcast_missing_geo_values")
@@ -647,8 +651,8 @@ covidcast_days <- function(data_source, signal, start_day, end_day, geo_type,
 
   if (nrow(df) > 0) {
     # If no data is found, there is no time_value column to report
-    df$time_value <- as.Date(as.character(df$time_value), format = "%Y%m%d")
-    df$issue <- as.Date(as.character(df$issue), format = "%Y%m%d")
+    df$time_value <- api_to_date(df$time_value)
+    df$issue <- api_to_date(df$issue)
     df$data_source <- data_source
     df$signal <- signal
 
@@ -668,7 +672,7 @@ geo_warning_message <- function(row, desired_geos) {
   if (length(missing_geos) > 0) {
     missing_geos_str <- paste0(missing_geos, collapse = ", ")
     err_msg <- sprintf("Data not fetched for some geographies on %s: %s",
-                   ymd(row$time_value), missing_geos_str)
+                       api_to_date(row$time_value), missing_geos_str)
     return(err_msg)
   }
 }
@@ -754,4 +758,9 @@ covidcast <- function(data_source, signal, time_type, geo_type, time_values,
 # This is the date format expected by the API
 date_to_string <- function(mydate) {
   format(mydate, "%Y%m%d")
+}
+
+# Convert dates from API to Date objects
+api_to_date <- function(str) {
+  as.Date(as.character(str), format = "%Y%m%d")
 }

--- a/R-packages/covidcast/R/covidcast.R
+++ b/R-packages/covidcast/R/covidcast.R
@@ -591,9 +591,9 @@ covidcast_days <- function(data_source, signal, start_day, end_day, geo_type,
       desired_geos <- tolower(unique(geo_value))
       returned_epidata <- dat[[i]]$epidata
       returned_geo_array <- returned_epidata %>%
-        select(geo_value, time_value) %>%
-        group_by(time_value) %>%
-        summarize(geo_value = list(geo_value))
+        dplyr::select(geo_value, time_value) %>%
+        dplyr::group_by(time_value) %>%
+        dplyr::summarize(geo_value = list(geo_value))
       returned_time_values <- returned_geo_array$time_value
       if (length(returned_time_values) != length(time_values)) {
         missing_time_values <- setdiff(time_values, returned_time_values)

--- a/R-packages/covidcast/tests/testthat/test-covidcast.R
+++ b/R-packages/covidcast/tests/testthat/test-covidcast.R
@@ -1,7 +1,6 @@
 library(covidcast)
 library(httptest)
 library(mockery)
-library(lubridate)
 library(dplyr)
 
 # Many of these tests use mockery::with_mock_api. This replaces calls to the
@@ -145,7 +144,7 @@ test_that("covidcast_days does not treat \"*\" as a missing geo_value", {
          signal = "signal",
          time_value = c(20201030, 20201031),
          direction = NA,
-         issue = ymd("2020-11-04"),
+         issue = as.Date("2020-11-04"),
          lag = 2,
          value = 3,
          stderr = NA,
@@ -156,8 +155,8 @@ test_that("covidcast_days does not treat \"*\" as a missing geo_value", {
     covidcast_days(
       data_source = "fb-survey",
       signal = "raw_cli",
-      start_day = ymd("2020-10-30"),
-      end_day = ymd("2020-10-31"),
+      start_day = as.Date("2020-10-30"),
+      end_day = as.Date("2020-10-31"),
       geo_type = "county",
       geo_value = c("*"),
       as_of = NULL,
@@ -174,7 +173,7 @@ test_that("covidcast_days does not raise warnings for full response", {
          signal = "signal",
          time_value = c(20201030, 20201031),
          direction = NA,
-         issue = ymd("2020-11-04"),
+         issue = as.Date("2020-11-04"),
          lag = 2,
          value = 3,
          stderr = NA,
@@ -185,8 +184,8 @@ test_that("covidcast_days does not raise warnings for full response", {
     covidcast_days(
       data_source = "fb-survey",
       signal = "raw_cli",
-      start_day = ymd("2020-10-30"),
-      end_day = ymd("2020-10-31"),
+      start_day = as.Date("2020-10-30"),
+      end_day = as.Date("2020-10-31"),
       geo_type = "county",
       geo_value = c("geoa"),
       as_of = NULL,
@@ -202,7 +201,7 @@ test_that("covidcast_days batches calls to covidcast", {
     signal = "signal",
     time_value = rep(NA, 3),
     direction = NA,
-    issue = ymd("2020-11-04"),
+    issue = as.Date("2020-11-04"),
     lag = 2,
     value = 3,
     stderr = NA,
@@ -217,8 +216,8 @@ test_that("covidcast_days batches calls to covidcast", {
       covidcast_days(
         data_source = "fb-survey",
         signal = "raw_cli",
-        start_day = ymd("2020-10-01"),
-        end_day = ymd("2020-10-06"),
+        start_day = as.Date("2020-10-01"),
+        end_day = as.Date("2020-10-06"),
         geo_type = "county",
         geo_value = "*",
         as_of = NULL,


### PR DESCRIPTION
Bizarrely, even though `R CMD check` passed perfectly, the uses of dplyr and lubridate introduced in #275 didn't actually work in the installed package:

```
> library(covidcast)
> symptoms <- covidcast_signal("fb-survey", "smoothed_hh_cmnty_cli", geo_type="state")
Fetched day 2020-04-15 to 2020-06-23: 1, success, num_entries = 3601
Error in summarize(., geo_value = list(geo_value)) : 
  could not find function "summarize"
> # and after fixing that:
> foo = covidcast_signal("fb-survey", "smoothed_hh_cmnty_cli", start_day="2020-11-20", end_day="2020-11-24", geo_type="state")
Fetched day 2020-11-20 to 2020-11-24: 1, success, num_entries = 153
Error in ymd(missing_time_values) : could not find function "ymd"
```

This is because there was no `@importFrom lubridate ymd` or equivalent, or the same for dplyr, so these functions are not in the package `NAMESPACE`.

I've fixed dplyr here by using the `dplyr::` prefix, and simply replaced the `ymd()` calls with a short function, since we were already using `as.Date()` for the same purpose in several places.

I'm not sure why the tests worked -- this is exactly the kind of problem testing should have detected. Maybe because some of the test files use dplyr, it was in the namespace, and none of the tests exercise the code that called `ymd()`? Dunno.