### PR TITLE
Update R plotting metadata check

### DIFF
--- a/R-packages/covidcast/DESCRIPTION
+++ b/R-packages/covidcast/DESCRIPTION
@@ -60,3 +60,4 @@ Suggests:
     tibble,
     vdiffr
 VignetteBuilder: knitr
+Config/testthat/edition: 3

--- a/R-packages/covidcast/R/plot.R
+++ b/R-packages/covidcast/R/plot.R
@@ -110,7 +110,8 @@ plot.covidcast_signal = function(x, plot_type = c("choro", "bubble", "line"),
   # For the maps, set range, if we need to (to mean +/- 3 standard deviations,
   # from metadata) 
   if (is.null(range) && (plot_type == "choro" || plot_type == "bubble")) {
-    if (is.null(attributes(x)$metadata)) { 
+    if (is.null(attributes(x)$metadata$mean_value) || 
+        is.null(attributes(x)$metadata$stdev_value)) { 
       warn(paste("Metadata for signal mean and standard deviation not",
                  "available; defaulting to observed mean and standard",
                  "deviation to set plot range."),

--- a/R-packages/covidcast/tests/testthat/test-plot.R
+++ b/R-packages/covidcast/tests/testthat/test-plot.R
@@ -133,9 +133,7 @@ test_that("warn on incomplete metadata", {
   
   expect_warning(plot(fake_data), NA) 
   attributes(fake_data)$metadata = list(geo_type = "state", mean_value = 0)
-  
+
   expect_warning(plot(fake_data),
-                 "Metadata for signal mean and standard deviation not",
-                 "available; defaulting to observed mean and standard",
-                 "deviation to set plot range.")
+                 class="covidcast_plot_meta_not_found")
 })

--- a/R-packages/covidcast/tests/testthat/test-plot.R
+++ b/R-packages/covidcast/tests/testthat/test-plot.R
@@ -116,3 +116,23 @@ test_that("simple county bubble plot", {
                       suppressWarnings(
                         plot(fb_county, plot_type = "bubble")))
 })
+
+
+test_that("test incomplete metadata", {
+  fake_data <- structure(data.frame(
+    data_source = "foo",
+    signal = "bar",
+    value = c(1, 2, 0, 3),
+    geo_value = c("pa", "in", "tx", "wy"),
+    time_value = as.Date("2020-01-01"),
+    issue = as.Date("2020-02-01"),
+    stderr = 0.5),
+    class = c("covidcast_signal", "data.frame"),
+    metadata = list(geo_type = "state")
+  )
+  
+  expect_warning(plot(fake_data),
+                 "Metadata for signal mean and standard deviation not",
+                 "available; defaulting to observed mean and standard",
+                 "deviation to set plot range.")
+})

--- a/R-packages/covidcast/tests/testthat/test-plot.R
+++ b/R-packages/covidcast/tests/testthat/test-plot.R
@@ -128,8 +128,11 @@ test_that("test incomplete metadata", {
     issue = as.Date("2020-02-01"),
     stderr = 0.5),
     class = c("covidcast_signal", "data.frame"),
-    metadata = list(geo_type = "state")
+    metadata = list(geo_type = "state", mean_value = 0, stdev_value = 1)
   )
+  
+  expect_warning(plot(fake_data), NA) 
+  attributes(fake_data)$metadata = list(geo_type = "state", mean_value = 0)
   
   expect_warning(plot(fake_data),
                  "Metadata for signal mean and standard deviation not",

--- a/R-packages/covidcast/tests/testthat/test-plot.R
+++ b/R-packages/covidcast/tests/testthat/test-plot.R
@@ -118,7 +118,7 @@ test_that("simple county bubble plot", {
 })
 
 
-test_that("test incomplete metadata", {
+test_that("warn on incomplete metadata", {
   fake_data <- structure(data.frame(
     data_source = "foo",
     signal = "bar",


### PR DESCRIPTION
Fixes #270 

Summary of changes
- Update the metadata check in the plotting function to look specifically at mean and stdev values
- Add test that the warning is raised if one of the values is missing and not raised if both are present.