### PR TITLE
Correct logic in check_valid_forecaster_output

### DIFF
--- a/R-packages/evalcast/R/evaluate.R
+++ b/R-packages/evalcast/R/evaluate.R
@@ -173,9 +173,9 @@ check_valid_forecaster_output <- function(pred_card) {
   wrong_format <- pred_card$forecast_distribution %>%
     map_lgl(~ any(names(.x) != c("probs", "quantiles")))
   wrong_probs <- pred_card$forecast_distribution %>%
-    map_lgl(~ all(abs(.x$probs - covidhub_probs) > 1e-8))
+    map_lgl(~ any(abs(.x$probs - covidhub_probs) > 1e-8))
   bad_quantiles <- pred_card$forecast_distribution %>%
-    map_lgl(~ all(diff(.x$quantiles) < -1e-8))
+    map_lgl(~ any(diff(.x$quantiles) < -1e-8))
   pred_card %>%
     mutate(null_forecasts = null_forecasts,
            wrong_probs = wrong_probs,


### PR DESCRIPTION
I was wondering why I was able to evaluate prediction cards for incident case forecasts in spite of them not using the set of probabilities that is hardcoded as a reference as mentioned in #100. Looking into it, I think I may have found a bug in the logic which checks the probabilities and quantiles. I'm opening this pull request just in case I'm correct and you are not aware of this problem. This change does seem to make #100 more urgent though. 