### PR TITLE
interval_coverage update

### DIFF
--- a/R-packages/evalcast/R/err_measures.R
+++ b/R-packages/evalcast/R/err_measures.R
@@ -92,7 +92,7 @@ absolute_error <- function(quantile, value, actual_value) {
 #' covers the actual value. The interval is defined as the (alpha/2)-quantile
 #' to the (1 - alpha/2)-quantile, where alpha = 1 - coverage.
 #'
-#' @param width Nominal interval coverage (from 0 to 1).
+#' @param coverage Nominal interval coverage (from 0 to 1).
 #'
 #' @export
 interval_coverage <- function(coverage) {

--- a/R-packages/evalcast/R/evaluate.R
+++ b/R-packages/evalcast/R/evaluate.R
@@ -60,7 +60,7 @@ evaluate_predictions <- function(
   predictions_cards,
   err_measures = list(wis = weighted_interval_score,
                       ae = absolute_error,
-                      coverage_80 = interval_coverage(alpha = 0.2)),
+                      coverage_80 = interval_coverage(coverage = 0.8)),
   backfill_buffer = 10,
   side_truth = NULL,
   grp_vars = c("forecaster", "forecast_date", "ahead", "location")) {

--- a/R-packages/evalcast/tests/testthat/test-err-measures.R
+++ b/R-packages/evalcast/tests/testthat/test-err-measures.R
@@ -1,0 +1,28 @@
+test_that("coverage calulations are accurate", {
+  quantiles = c(0.01, 0.05, 0.1, 0.3, 0.5, 0.7, 0.9, 0.95, 0.99)
+  value = c(1, 5, 10, 30, 50, 70, 90, 95, 99)
+  
+  expect_false(interval_coverage(0.8)(quantiles, value, 9.9))
+  expect_true(interval_coverage(0.8)(quantiles, value, 10.1))
+  expect_true(interval_coverage(0.8)(quantiles, value, 89.9))
+  expect_false(interval_coverage(0.8)(quantiles, value, 90.1))
+  
+  expect_false(interval_coverage(0.4)(quantiles, value, 29.9))
+  expect_true(interval_coverage(0.4)(quantiles, value, 30.1))
+  expect_true(interval_coverage(0.4)(quantiles, value, 69.9))
+  expect_false(interval_coverage(0.4)(quantiles, value, 70.1))
+})
+
+test_that("Warning when appropriate quantiles don't exist", {
+  quantiles = c(0.01, 0.05, 0.1, 0.3, 0.5, 0.7, 0.9, 0.95, 0.99)
+  value = c(1, 5, 10, 30, 50, 70, 90, 95, 99)
+  
+  expect_warning(interval_coverage(0.75)(quantiles, value, 9.9))
+})
+
+test_that("Warning when duplicate quantiles", {
+  quantiles = c(0.01, 0.05, 0.1, 0.3, 0.3, 0.7, 0.9, 0.95, 0.99)
+  value = c(1, 5, 10, 30, 50, 70, 90, 95, 99)
+  
+  expect_warning(interval_coverage(0.8)(quantiles, value, 9.9))
+})


### PR DESCRIPTION
Fixes a bug in `interval_coverage` (`which.min` was applied to a logical vector)
Change parameter to be coverage proportion instead of alpha = (1 - coverage)
Adds tests
Minor readability changes