### PR TITLE
[Draft] Add condition to skip problematic tests on version 3.5

### DIFF
--- a/.github/workflows/r_ci.yml
+++ b/.github/workflows/r_ci.yml
@@ -22,7 +22,7 @@ jobs:
         working-directory: R-packages/covidcast/
     strategy:
       matrix:
-        r-version: [3.5]
+        r-version: [3.5, 3.6]
 
     steps:
       - uses: actions/checkout@v2

--- a/R-packages/covidcast/tests/testthat/test-plot.R
+++ b/R-packages/covidcast/tests/testthat/test-plot.R
@@ -58,6 +58,8 @@ test_that("state line graphs", {
 })
 
 test_that("simple state choropleths", {
+  skip_if(startsWith(R.Version()$minor, "5") & R.Version()$major == "3",
+          "Only test on R 3.6+")
   fb_state <- readRDS(test_path("data/survey-data-state.rds"))
 
   expect_doppelganger("default state choropleth",


### PR DESCRIPTION
R 3.5 has a slightly different SVG encoding that yields visually identical plots but they fail vdiffr (see [this slack thread](https://delphi-org.slack.com/archives/C01E5M9KVN1/p1606775799011500) for more info). In #337 @sarah-colq is updating the CI to run on R 3.6 so tests pass, and this closes #350 which was opened as a follow up ticket. 