### PR TITLE
Add function to convert epiweeks to timestamps

### DIFF
--- a/.github/workflows/r_covidcast_ci.yml
+++ b/.github/workflows/r_covidcast_ci.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install linux dependencies
         run: |
             sudo apt-get install libcurl4-openssl-dev
-            sudo apt-get install libgit2
+            sudo apt-get install libgit2-dev
       - name: Cache R packages
         uses: actions/cache@v2
         with:

--- a/.github/workflows/r_covidcast_ci.yml
+++ b/.github/workflows/r_covidcast_ci.yml
@@ -30,8 +30,10 @@ jobs:
         uses: r-lib/actions/setup-r@v1
         with:
           r-version: ${{ matrix.r-version }}
-      - name: Install libcurl
-        run: sudo apt-get install libcurl4-openssl-dev
+      - name: Install linux dependencies
+        run: |
+            sudo apt-get install libcurl4-openssl-dev
+            sudo apt-get install libgit2
       - name: Cache R packages
         uses: actions/cache@v2
         with:

--- a/Python-packages/covidcast-py/covidcast/covidcast.py
+++ b/Python-packages/covidcast-py/covidcast/covidcast.py
@@ -226,10 +226,12 @@ def metadata() -> pd.DataFrame:
         metadata.
 
       ``min_time``
-        First day for which this signal is available.
+        First day for which this signal is available. For weekly signals, will be
+        the first day of the epiweek.
 
       ``max_time``
-        Most recent day for which this signal is available.
+        Most recent day for which this signal is available. For weekly signals, will be
+        the first day of the epiweek.
 
       ``num_locations``
         Number of distinct geographic locations available for this signal. For

--- a/Python-packages/covidcast-py/covidcast/covidcast.py
+++ b/Python-packages/covidcast-py/covidcast/covidcast.py
@@ -270,8 +270,8 @@ def metadata() -> pd.DataFrame:
                            meta["message"])
 
     meta_df = pd.DataFrame.from_dict(meta["epidata"])
-    meta_df["min_time"] = meta_df["min_time"].astype(str).apply(_parse_datetime_weeks)
-    meta_df["max_time"] = meta_df["max_time"].astype(str).apply(_parse_datetime_weeks)
+    meta_df["min_time"] = meta_df.apply(lambda x: _parse_datetimes(x.min_time, x.time_type), axis=1)
+    meta_df["max_time"] = meta_df.apply(lambda x: _parse_datetimes(x.max_time, x.time_type), axis=1)
     meta_df["last_update"] = pd.to_datetime(meta_df["last_update"], unit="s")
     return meta_df
 
@@ -328,8 +328,9 @@ def aggregate_signals(signals: list, dt: list = None, join_type: str = "outer") 
     return joined_df
 
 
-def _parse_datetime_weeks(date_str: str,
-                          format: str="%Y%m%d") -> Union[pd.Timestamp]:  # annotating nan errors
+def _parse_datetimes(date_int: int,
+                     time_type: str,
+                     format: str="%Y%m%d") -> Union[pd.Timestamp]:  # annotating nan errors
     """Convert a date or epiweeks string into timestamp objects.
 
     Datetimes (length 8) are converted to their corresponding date, while epiweeks (length 6)
@@ -337,13 +338,14 @@ def _parse_datetime_weeks(date_str: str,
 
     Epiweeks use the CDC format.
 
-    :param date_str: String of date or epiweek
+    :param date_int: Int representation of date.
     :param format: String of the date format to parse.
-    :returns: Timestamp
+    :returns: Timestamp.
     """
-    if len(date_str) == 8:
+    date_str = str(date_int)
+    if time_type == "day":
         return pd.to_datetime(date_str, format=format)
-    elif len(date_str) == 6:
+    elif time_type == "week":
         epiwk = Week(int(date_str[:4]), int(date_str[-2:]))
         return pd.to_datetime(epiwk.startdate())
     else:

--- a/Python-packages/covidcast-py/covidcast/covidcast.py
+++ b/Python-packages/covidcast-py/covidcast/covidcast.py
@@ -328,11 +328,11 @@ def aggregate_signals(signals: list, dt: list = None, join_type: str = "outer") 
     return joined_df
 
 
-def _parse_datetime_weeks(date_str: str, format="%Y%m%d") -> str:
+def _parse_datetime_weeks(date_str: str, format: str="%Y%m%d") -> Union[pd.Timestamp, np.nan]:
     """Convert a date or epiweeks string into timestamp objects.
 
     Datetimes (length 8) are converted to their corresponding date, while epiweeks (length 6)
-    are converted to the date of the start of the week.
+    are converted to the date of the start of the week. Returns nan otherwise
 
     Epiweeks use the CDC format.
 

--- a/Python-packages/covidcast-py/covidcast/covidcast.py
+++ b/Python-packages/covidcast-py/covidcast/covidcast.py
@@ -328,7 +328,8 @@ def aggregate_signals(signals: list, dt: list = None, join_type: str = "outer") 
     return joined_df
 
 
-def _parse_datetime_weeks(date_str: str, format: str="%Y%m%d") -> Union[pd.Timestamp, np.nan]:
+def _parse_datetime_weeks(date_str: str,
+                          format: str="%Y%m%d") -> Union[pd.Timestamp]:  # annotating nan errors
     """Convert a date or epiweeks string into timestamp objects.
 
     Datetimes (length 8) are converted to their corresponding date, while epiweeks (length 6)

--- a/Python-packages/covidcast-py/docs/changelog.rst
+++ b/Python-packages/covidcast-py/docs/changelog.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+
+v0.1.2, December 10, 2020
+-------------------------
+
+- Bug fix: Fix issue where introduction of weekly signals broke :py:func:`covidcast.metadata` function.
+
 v0.1.1, November 22, 2020
 -------------------------
 

--- a/Python-packages/covidcast-py/docs/changelog.rst
+++ b/Python-packages/covidcast-py/docs/changelog.rst
@@ -5,7 +5,7 @@ Changelog
 v0.1.2, December 10, 2020
 -------------------------
 
-- Bug fix: Fix issue where introduction of weekly signals broke :py:func:`covidcast.metadata` function.
+- Bug fix: Fix issue where introduction of weekly signals broke the :py:func:`covidcast.metadata` function.
 
 v0.1.1, November 22, 2020
 -------------------------

--- a/Python-packages/covidcast-py/setup.py
+++ b/Python-packages/covidcast-py/setup.py
@@ -29,7 +29,8 @@ setuptools.setup(
         "descartes",
         "imageio-ffmpeg",
         "imageio",
-        "tqdm"
+        "tqdm",
+        "epiweeks"
     ],
     package_data={"covidcast": ["shapefiles/*/*", "geo_mappings/*"]}
 )

--- a/Python-packages/covidcast-py/tests/test_covidcast.py
+++ b/Python-packages/covidcast-py/tests/test_covidcast.py
@@ -80,8 +80,8 @@ def test_metadata(mock_covidcast_meta):
     # not generating full DF since most attributes used
     mock_covidcast_meta.side_effect = [
         {"result": 1,  # successful API response
-         "epidata": [{"max_time": 20200622, "min_time": 20200421, "last_update": 12345},
-                     {"max_time": 20200724, "min_time": 20200512, "last_update": 99999}],
+         "epidata": [{"max_time": 20200622, "min_time": 20200421, "last_update": 12345, "time_type": "day"},
+                     {"max_time": 20200724, "min_time": 20200512, "last_update": 99999, "time_type": "day"}],
          "message": "success"},
         {"result": 0,  # unsuccessful API response
          "epidata": [{"max_time": 20200622, "min_time": 20200421},
@@ -92,7 +92,8 @@ def test_metadata(mock_covidcast_meta):
     expected = pd.DataFrame({
         "max_time": [datetime(2020, 6, 22), datetime(2020, 7, 24)],
         "min_time": [datetime(2020, 4, 21), datetime(2020, 5, 12)],
-        "last_update": [datetime(1970, 1, 1, 3, 25, 45), datetime(1970, 1, 2, 3, 46, 39)]})
+        "last_update": [datetime(1970, 1, 1, 3, 25, 45), datetime(1970, 1, 2, 3, 46, 39)],
+        "time_type": ["day", "day"]})
     assert sort_df(response).equals(sort_df(expected))
 
     # test failed response raises RuntimeError
@@ -178,10 +179,10 @@ def test_aggregate_signals():
         covidcast.aggregate_signals([test_input1, test_input4])
 
 
-def test__parse_datetime_weeks():
-    assert covidcast._parse_datetime_weeks("202001") == pd.Timestamp(Week(2020, 1).startdate())
-    assert covidcast._parse_datetime_weeks("20200205") == pd.Timestamp("20200205")
-    assert pd.isna(covidcast._parse_datetime_weeks("2020"))
+def test__parse_datetimes():
+    assert covidcast._parse_datetimes("202001", "week") == pd.Timestamp(Week(2020, 1).startdate())
+    assert covidcast._parse_datetimes("20200205", "day") == pd.Timestamp("20200205")
+    assert pd.isna(covidcast._parse_datetimes("2020", "test"))
 
 
 def test__detect_metadata():

--- a/Python-packages/covidcast-py/tests/test_covidcast.py
+++ b/Python-packages/covidcast-py/tests/test_covidcast.py
@@ -10,6 +10,7 @@ matplotlib.use("AGG")
 import pandas as pd
 import numpy as np
 import pytest
+from epiweeks import Week
 from covidcast import covidcast
 from covidcast.errors import NoDataWarning
 
@@ -175,6 +176,12 @@ def test_aggregate_signals():
          "data_source": ["z", "z", "z", "z"]})
     with pytest.raises(ValueError):
         covidcast.aggregate_signals([test_input1, test_input4])
+
+
+def test__parse_datetime_weeks():
+    assert covidcast._parse_datetime_weeks("202001") == pd.Timestamp(Week(2020, 1).startdate())
+    assert covidcast._parse_datetime_weeks("20200205") == pd.Timestamp("20200205")
+    assert pd.isna(covidcast._parse_datetime_weeks("2020"))
 
 
 def test__detect_metadata():


### PR DESCRIPTION
See [this slack thread](https://delphi-org.slack.com/archives/C01E5M9KVN1/p1607616621001000).

Add a function that converts dates to timestamps and epiweek dates (CDC format, defined as length 6) to timestamps. Epiweeks are converted to the start of the epiweek using the `epiweeks` package.

Updated d ocs and changelog too, so I think we're good to rebuild docs and then release 0.1.2 after this is merged