### PR TITLE
Update r_evalcast_ci.yml

### DIFF
--- a/.github/workflows/r_evalcast_ci.yml
+++ b/.github/workflows/r_evalcast_ci.yml
@@ -35,6 +35,7 @@ jobs:
             sudo apt-get install libcurl4-openssl-dev
             sudo apt-get install libudunits2-dev
             sudo apt-get install libgdal-dev
+            sudo apt-get install libicu-dev
       - name: Cache R packages
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
CI failing because we need the [ICU library](http://site.icu-project.org/download).

(I'll need this on `evalcast` as well).