### PR TITLE
Remove quantile information from scorecards

### DIFF
--- a/R-packages/evalcast/R/err_measures.R
+++ b/R-packages/evalcast/R/err_measures.R
@@ -13,8 +13,15 @@
 #' 
 #' @export
 weighted_interval_score <- function(quantile, value, actual_value) {
- 
   if (all(is.na(actual_value))) return(NA)
+  actual_value <- unique(actual_value)
+  assert_that(length(actual_value) == 1,
+              msg = "actual_value must only have 1 value")
+  assert_that(length(quantile) == length(value),
+              msg = "quantiles and values must be of the same length")
+
+  value <- value[!is.na(quantile)]
+  quantile <- quantile[!is.na(quantile)]
   
   # per Ryan: WIS is equivalent to quantile loss modulo an extra 0.5 AE term
   # for the median forecast (counted twice). 

--- a/R-packages/evalcast/R/evaluate.R
+++ b/R-packages/evalcast/R/evaluate.R
@@ -28,10 +28,10 @@
 #' to the user to determine.  If backfill is not relevant for the particular
 #' signal you are predicting, then you can set `backfill_buffer` to 0.
 #'
-#' @param predictions_cards tibble of predictions 
+#' @param predictions_cards tibble of predictions
 #'   that are all for the same prediction task, meaning they are for the same
 #'   response, incidence period,and geo type. Forecasts may be for a
-#'   different forecast date or forecaster.  
+#'   different forecast date or forecaster.
 #'   A predictions card may be created by the function
 #'   [get_predictions()], downloaded with [get_covidhub_predictions()] or
 #'   possibly created manually.
@@ -41,19 +41,19 @@
 #' @param backfill_buffer How many days until response is deemed trustworthy
 #'   enough to be taken as correct? See details for more.
 #' @param side_truth you can optionally provide your own truth data (observed).
-#'   Adding this column bypasses all checks to get appropriate data as 
+#'   Adding this column bypasses all checks to get appropriate data as
 #'   reported at the time of the forecast. This column should either be a vector
-#'   the same length as `predictions_cards` or a data frame that will be 
+#'   the same length as `predictions_cards` or a data frame that will be
 #'   joined to `predictions_cards` by all available columns. If a data frame,
-#'   the observed data should be named `actual` 
+#'   the observed data should be named `actual`
 #' @param grp_vars character vector of named columns in the predictions_cards
 #'  such that the combination gives a unique (quantile) prediction. Ignored if
 #'  `predictions_cards` is of the type returned by [get_covidhub_predictions()]
 #'  or [get_predictions()] (class is `predictions_cards`)
-#' 
+#'
 #' @return tibble of "score cards". Contains the same information as the
 #'   `predictions_cards()` with additional columns for each err_measure and
-#'   for the truth (named `actual`). All the columns may be necessary for 
+#'   for the truth (named `actual`). All the columns may be necessary for
 #'   some types of plotting, but it may be useful to shrink this down
 #'
 #' @export
@@ -65,7 +65,7 @@ evaluate_predictions <- function(
   backfill_buffer = 10,
   side_truth = NULL,
   grp_vars = c("forecaster", "forecast_date", "ahead", "geo_value")) {
-  
+
   assert_that("predictions_cards" %in% class(predictions_cards) ||
                 !is.null(side_truth),
               msg = paste("In evaluate_predictions: either predictions_cards",
@@ -73,128 +73,112 @@ evaluate_predictions <- function(
                           "appropriate responses can be downloaded from",
                           "covidcast, or you must provide your own",
                           "ground truth."))
-  
-  # Computations if actuals are provided by the user
-  if (!is.null(side_truth)) {
+
+  # Construct predictions joined with real data
+  if (is.null(side_truth)) {
+    actual_data <- get_covidcast_data(predictions_cards, backfill_buffer)
+    predictions_cards <- left_join(predictions_cards,
+                                   actual_data,
+                                   by = c("geo_value",
+                                          "forecast_date",
+                                          "ahead"))
+  } else {
+    # Computations if actuals are provided by the user
     if (is.data.frame(side_truth)) {
-      predictions_cards <- left_join(predictions_cards, side_truth)
-      assert_that("actual" %in% names(predictions_cards),
+      actual_data <- side_truth
+      assert_that("actual" %in% names(side_truth),
                   msg = paste("When providing your own truth data as a data",
                               "frame, one column must be named `actual`"))
+      predictions_cards <- left_join(predictions_cards, side_truth)
     } else {
       predictions_cards <- bind_cols(predictions_cards, actual = side_truth)
     }
-    if (class(predictions_cards)[1] == "predictions_cards" &&
-        is.null(grp_vars)) {
-      grp_vars = c("forecaster", "forecast_date", "ahead", "geo_value")
-    }
-    score_card <- predictions_cards %>% group_by(across(all_of(grp_vars)))
-    sc_keys <- score_card %>% group_keys()
-    score_card <- score_card %>%
-      group_split() %>%
-      lapply(erm, err_measures=err_measures) %>%
-      bind_rows() %>%
-      bind_cols(sc_keys) %>%
-      inner_join(predictions_cards, by=grp_vars)
-    class(score_card) <- c("score_cards", class(score_card))
-    attributes(score_card) <- c(attributes(score_card), 
-                                as_of = lubridate::as_date(Sys.Date()))
-    return(score_card)
   }
-  
-  
-  # more heavy lifting if we are grabbing data from covidcast
-  unique_ahead <- select(predictions_cards, .data$ahead) %>% 
-    distinct() %>% pull()
-  scorecards <- list()
-  for (i in seq_along(unique_ahead)) {
-    message("ahead = ", unique_ahead[i])
-    scorecards[[i]] <- evaluate_predictions_single_ahead(
-      filter(predictions_cards, .data$ahead == unique_ahead[i]),
-      err_measures = err_measures,
-      backfill_buffer = backfill_buffer)
-  }
-  scorecards <- bind_rows(scorecards)
-  class(scorecards) <- c("score_cards", class(scorecards))
-  return(scorecards)
-}
 
-#' Create score cards for a single ahead value.
-evaluate_predictions_single_ahead <- function(predictions_cards,
-                                              err_measures,
-                                              backfill_buffer) {
-  
-  response <- predictions_cards %>% 
-    select(.data$data_source, .data$signal) %>% distinct()
-  assert_that(nrow(response) == 1,
-              msg="All predictions cards should have the same response.")
-  incidence_period <- unique_for_ahead(predictions_cards, "incidence_period")
-  geo_type_len <- unique_for_ahead(
-    select(predictions_cards, .data$geo_value, .data$ahead) %>%
-      mutate(geo_type = nchar(.data$geo_value)), 
-    "geo_type")
-  geo_type <- ifelse(geo_type_len == 2L, "state", "county")
-  forecast_dates <- select(predictions_cards, .data$forecast_date) %>%
-    distinct() %>% pull()
-  ahead <- predictions_cards$ahead[1]
-  geo_values <- select(predictions_cards, .data$geo_value) %>%
-    distinct() %>% pull()
-  
-  # calculate the actual value we're trying to predict:
-  target_response <- get_target_response(response,
-                                         forecast_dates,
-                                         incidence_period,
-                                         ahead,
-                                         geo_type,
-                                         geo_values)
-  if (nrow(target_response) == 0) {
-    return(empty_score_card(predictions_cards, err_measures))
-  }
-  as_of <- attr(target_response, "as_of")
-  . <- "got this idea from https://github.com/tidyverse/magrittr/issues/29"
-  if (as_of < max(target_response$end) + backfill_buffer) {
-    warning(target_response %>% filter(.data$end == max(.data$end)) %>%
-              stringr::str_glue_data(
-              "Reliable data for evaluation is not yet available for ",
-              "`forecast_date` of {forecast_date} because target period ",
-              "extends to {end} which is too recent to be reliable ",
-              "according to the provided `backfill_buffer` of ",
-              "{backfill_buffer}.", forecast_date=.$forecast_date[1],
-              end=.$end[1], backfill_buffer=backfill_buffer))
-  }
-  
-  # join together the data frames target_response and predicted:
-  score_card <- target_response %>%
-    inner_join(predictions_cards, by = c("geo_value", "forecast_date")) 
-  # compute the error
-  
-  score_card <- score_card %>%
-    group_by(.data$forecaster, .data$geo_value, .data$forecast_date)
+  score_card <- predictions_cards %>% group_by(across(all_of(grp_vars)))
   sc_keys <- score_card %>% group_keys()
-  
-  # split-apply-recombine
-  score_card <- score_card %>% 
-    group_split() %>%
-    lapply(erm, err_measures=err_measures) %>%
-    bind_rows() %>%
-    bind_cols(sc_keys)
-  
-  # now add back the other data
   score_card <- score_card %>%
-    left_join(target_response, by=c("geo_value", "forecast_date")) %>%
-    select(-.data$start, -.data$end) %>%
-    inner_join(predictions_cards,
-               by=c("forecaster", "geo_value", "forecast_date")) %>%
-    relocate(.data$ahead, .data$geo_value, .data$quantile, .data$value, 
-             .data$forecaster, .data$forecast_date, .data$data_source, 
-             .data$signal, .data$target_end_date, .data$incidence_period, 
-             .data$actual)
-    
-  attributes(score_card) <- c(attributes(score_card), 
-                              as_of = lubridate::as_date(as_of))
+    group_split() %>%
+    lapply(erm, err_measures = err_measures) %>%
+    bind_rows() %>%
+    bind_cols(sc_keys) %>%
+    inner_join(predictions_cards, by = grp_vars)
+  class(score_card) <- c("score_cards", class(score_card))
+  attributes(score_card) <- c(attributes(score_card),
+                              as_of = lubridate::as_date(Sys.Date()))
+  score_card <- collapse_cards(score_card)
+  score_card <- score_card %>%
+                 select(-c(quantile, value))
+  if (is.null(side_truth)) {
+    score_card <- score_card %>%
+                    relocate(.data$ahead, .data$geo_value, .data$forecaster,
+                             .data$forecast_date, .data$data_source,
+                             .data$signal, .data$target_end_date,
+                             .data$incidence_period, .data$actual)
+  }
+  score_card <- score_card %>%
+                 relocate(attr(err_measures, "name"), .after = last_col())
   return(score_card)
 }
 
+get_covidcast_data <- function(predictions_cards,
+                               backfill_buffer) {
+  response <- predictions_cards %>%
+                select(.data$data_source, .data$signal) %>%
+                distinct()
+  assert_that(nrow(response) == 1,
+              msg = "All predictions cards should have the same response.")
+  incidence_period <- unique(predictions_cards$incidence_period)
+  assert_that(length(incidence_period) == 1,
+              msg = "All predictions cards should have the same incidence
+                     period.")
+  geo_type_len <- predictions_cards %>%
+    mutate(type_len = nchar(geo_value)) %>%
+    distinct(type_len)
+  assert_that(nrow(geo_type_len) == 1,
+              msg = "All predictions cards should have the same geo_type.")
+  geo_type <- ifelse(geo_type_len$type_len == 2L, "state", "county")
+
+  unique_ahead <- select(predictions_cards, .data$ahead) %>%
+                    distinct() %>%
+                    pull()
+  actuals <- list()
+  for (i in seq_along(unique_ahead)) {
+    message("ahead = ", unique_ahead[i])
+    ahead <- unique_ahead[i]
+    predictions_cards_ahead <- filter(predictions_cards, .data$ahead == ahead)
+    forecast_dates <- select(predictions_cards_ahead, .data$forecast_date) %>%
+                        distinct() %>%
+                        pull()
+    geo_values <- select(predictions_cards_ahead, .data$geo_value) %>%
+                    distinct() %>%
+                    pull()
+
+    # calculate the actual value we're trying to predict:
+    target_response <- get_target_response(response,
+                                           forecast_dates,
+                                           incidence_period,
+                                           ahead,
+                                           geo_type,
+                                           geo_values)
+    target_response$ahead <- ahead
+    as_of <- attr(target_response, "as_of")
+    . <- "got this idea from https://github.com/tidyverse/magrittr/issues/29"
+    if (as_of < max(target_response$end) + backfill_buffer) {
+      warning(target_response %>% filter(.data$end == max(.data$end)) %>%
+                stringr::str_glue_data(
+                "Reliable data for evaluation is not yet available for ",
+                "`forecast_date` of {forecast_date} because target period ",
+                "extends to {end} which is too recent to be reliable ",
+                "according to the provided `backfill_buffer` of ",
+                "{backfill_buffer}.", forecast_date = .$forecast_date[1],
+                end = .$end[1], backfill_buffer = backfill_buffer))
+    }
+    actuals[[i]] <- target_response
+  }
+  response <- bind_rows(actuals) %>% select(-c(start, end))
+  return(response)
+}
 
 #' @importFrom rlang :=
 empty_score_card <- function(pcards, err_measures){

--- a/R-packages/evalcast/R/evaluate.R
+++ b/R-packages/evalcast/R/evaluate.R
@@ -85,7 +85,6 @@ evaluate_predictions <- function(
   } else {
     # Computations if actuals are provided by the user
     if (is.data.frame(side_truth)) {
-      actual_data <- side_truth
       assert_that("actual" %in% names(side_truth),
                   msg = paste("When providing your own truth data as a data",
                               "frame, one column must be named `actual`"))

--- a/R-packages/evalcast/R/manage_cards.R
+++ b/R-packages/evalcast/R/manage_cards.R
@@ -24,8 +24,10 @@ collapse_cards <- function(cards){
              value = ifelse(is.na(.data$p), .data$m, .data$p)) %>%
       select(-.data$p, -.data$m)
   }
-  cards <- cards %>% 
-    relocate(.data$quantile:.data$value, .after = .data$geo_value)
+  if ("geo_value" %in% colnames(cards)) {
+    cards <- cards %>%
+      relocate(.data$quantile:.data$value, .after = .data$geo_value)
+  }
   class(cards) = c(cls, class(cards))
   cards
 }


### PR DESCRIPTION
**Removes quantile information from scorecards**
Previously, scorecards contained a large quantity of duplicate information, since a row was created for each quantile. However, since overall error scores do not vary by quantile, the resulting tibbles had more rows than necessary, typically by a factor of 23.

This change removes `quantile` and `value` columns from scorecards, and fixes #400.

**Additional smaller changes:**
- Refactor `evaluate_predictions`
- Allow `weighted_interval_score` to process data that contains point estimates (i.e. `quantile = NA`, which does not affect the score)
- Remove requirement that dataframes passed to `collapse_cards` have a `geo_value` column

**Example with Covidcast data:**
```
forecaster = "CMU-TimeSeries"
forecast_dates = c("2020-09-21", "2020-09-28", "2020-10-05", "2020-10-12", "2020-10-19")
cmu_predictions = get_covidhub_predictions(forecaster, forecast_dates)
cmu_deaths = cmu_predictions %>% filter(signal == "deaths_incidence_num")
cmu_eval = evaluate_predictions(cmu_deaths)
> cmu_eval
# A tibble: 1,012 x 12
   ahead geo_value forecaster     forecast_date data_source signal               target_end_date incidence_period actual   wis    ae coverage_80
   <int> <chr>     <chr>          <date>        <chr>       <chr>                <date>          <chr>             <int> <dbl> <dbl>       <dbl>
 1     1 ak        CMU-TimeSeries 2020-09-21    jhu-csse    deaths_incidence_num 2020-09-26      epiweek               7  4.27     6           0
 2     1 al        CMU-TimeSeries 2020-09-21    jhu-csse    deaths_incidence_num 2020-09-26      epiweek              64 39.0     53           0
 3     1 ar        CMU-TimeSeries 2020-09-21    jhu-csse    deaths_incidence_num 2020-09-26      epiweek             104  8.98    16           1
```
**Example with side_data:**
```
test_data = data.frame(matrix(nrow = 23 * 4, ncol = 4))
colnames(test_data) = c("foo", "bar", "quantile", "value")

quantiles = cmu_deaths$quantile[1:23]
test_data$quantile = quantiles
test_data$value = 1:92
test_data$foo = c(rep("a", 46), rep("b", 46))
test_data$bar = c(rep("a", 23), rep("b", 23), rep("a", 23), rep("b", 23))
test_data = as_tibble(test_data)
test_data %>% arrange(foo, bar)

test_side_data = data.frame(matrix(nrow = 4, ncol = 3))
colnames(test_side_data) = c("foo", "bar", "actual")
test_side_data$foo = c("a", "b")
test_side_data$bar = c("a", "a", "b", "b")
test_side_data$actual = c(10:13)
test_side_data = as_tibble(test_side_data)

foo = evaluate_predictions(test_data, side_truth = test_side_data, grp_vars = c("foo", "bar"))
> foo
# A tibble: 4 x 6
  foo   bar   actual   wis    ae coverage_80
  <chr> <chr>  <int> <dbl> <dbl>       <dbl>
1 a     a         10  1.67     2           1
2 a     b         12 18.8     23           0
3 b     a         11 42.8     47           0
4 b     b         13 63.8     68           0
```

