### PR TITLE
minor change to documentation due to broken link

### DIFF
--- a/R-packages/modeltools/R/change.R
+++ b/R-packages/modeltools/R/change.R
@@ -3,7 +3,7 @@
 #' Computes the percentage change of the values in a `covidcast_signal` data
 #' frame. (When multiple issue dates are present, only the latest issue is
 #' considered.)  See the [percentage change
-#' vignette](https://cmu-delphi.github.io/covidcast/modeltools/articles/pct-change.html)
+#' vignette](https://cmu-delphi.github.io/covidcast/modeltoolsR/articles/pct-change.html)
 #' for examples.  
 #'
 #' @param x The `covidcast_signal` data frame under consideration.

--- a/R-packages/modeltools/R/deriv.R
+++ b/R-packages/modeltools/R/deriv.R
@@ -4,7 +4,7 @@
 #' a local (in time) linear regression or smoothing spline. (When multiple issue
 #' dates are present, only the latest issue is considered.)  See the
 #' [estimating derivatives
-#' vignette](https://cmu-delphi.github.io/covidcast/modeltools/articles/estimate-deriv.html)
+#' vignette](https://cmu-delphi.github.io/covidcast/modeltoolsR/articles/estimate-deriv.html)
 #' for examples.  
 #'
 #' @param x The `covidcast_signal` data frame under consideration. 

--- a/R-packages/modeltools/R/quantgen.R
+++ b/R-packages/modeltools/R/quantgen.R
@@ -3,7 +3,7 @@
 #' A simple quantile autoregressive forecaster based on `quantgen`, to be used
 #' with `evalcast`, via [evalcast::get_predictions()]. See the [quantgen
 #' forecast
-#' vignette](https://cmu-delphi.github.io/covidcast/modeltools/articles/quantgen-forecast.html)
+#' vignette](https://cmu-delphi.github.io/covidcast/modeltoolsR/articles/quantgen-forecast.html)
 #' for examples.
 #' 
 #' @param df Data frame of signal values to use for forecasting, of the format

--- a/R-packages/modeltools/R/slide.R
+++ b/R-packages/modeltools/R/slide.R
@@ -4,7 +4,7 @@
 #' Slides a given function over the values in a  `covidcast_signal` data frame,
 #' grouped by `geo_value`. (When multiple issue dates are present, only the
 #' latest issue is considered.) See the [getting started
-#' guide](https://cmu-delphi.github.io/covidcast/modeltools/articles/modeltools.html)
+#' guide](https://cmu-delphi.github.io/covidcast/modeltoolsR/articles/modeltools.html)
 #' for examples.    
 #'
 #' @param x The `covidcast_signal` data frame under consideration. 

--- a/R-packages/modeltools/man/estimate_deriv.Rd
+++ b/R-packages/modeltools/man/estimate_deriv.Rd
@@ -53,7 +53,7 @@ to the \code{col_name} argument, containing the estimated derivative values.
 Estimates derivatives of the values in a \code{covidcast_signal} data frame, using
 a local (in time) linear regression or smoothing spline. (When multiple issue
 dates are present, only the latest issue is considered.)  See the
-\href{https://cmu-delphi.github.io/covidcast/modeltools/articles/estimate-deriv.html}{estimating derivatives vignette}
+\href{https://cmu-delphi.github.io/covidcast/modeltoolsR/articles/estimate-deriv.html}{estimating derivatives vignette}
 for examples.
 }
 \details{

--- a/R-packages/modeltools/man/pct_change.Rd
+++ b/R-packages/modeltools/man/pct_change.Rd
@@ -26,6 +26,6 @@ to the \code{col_name} argument, containing the percentage change values.
 \description{
 Computes the percentage change of the values in a \code{covidcast_signal} data
 frame. (When multiple issue dates are present, only the latest issue is
-considered.)  See the \href{https://cmu-delphi.github.io/covidcast/modeltools/articles/pct-change.html}{percentage change vignette}
+considered.)  See the \href{https://cmu-delphi.github.io/covidcast/modeltoolsR/articles/pct-change.html}{percentage change vignette}
 for examples.
 }

--- a/R-packages/modeltools/man/quantgen_forecaster.Rd
+++ b/R-packages/modeltools/man/quantgen_forecaster.Rd
@@ -139,6 +139,6 @@ quantile forecasts for that location and ahead.
 }
 \description{
 A simple quantile autoregressive forecaster based on \code{quantgen}, to be used
-with \code{evalcast}, via \code{\link[evalcast:get_predictions]{evalcast::get_predictions()}}. See the \href{https://cmu-delphi.github.io/covidcast/modeltools/articles/quantgen-forecast.html}{quantgen forecast vignette}
+with \code{evalcast}, via \code{\link[evalcast:get_predictions]{evalcast::get_predictions()}}. See the \href{https://cmu-delphi.github.io/covidcast/modeltoolsR/articles/quantgen-forecast.html}{quantgen forecast vignette}
 for examples.
 }

--- a/R-packages/modeltools/man/slide_by_geo.Rd
+++ b/R-packages/modeltools/man/slide_by_geo.Rd
@@ -46,6 +46,6 @@ to the \code{col_name} argument, containing the function values.
 \description{
 Slides a given function over the values in a  \code{covidcast_signal} data frame,
 grouped by \code{geo_value}. (When multiple issue dates are present, only the
-latest issue is considered.) See the \href{https://cmu-delphi.github.io/covidcast/modeltools/articles/modeltools.html}{getting started guide}
+latest issue is considered.) See the \href{https://cmu-delphi.github.io/covidcast/modeltoolsR/articles/modeltools.html}{getting started guide}
 for examples.
 }

--- a/docs/modeltoolsR/reference/estimate_deriv.html
+++ b/docs/modeltoolsR/reference/estimate_deriv.html
@@ -6,7 +6,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>Estimate derivatives of values in <code>covidcast_signal</code> data frame — estimate_deriv • modeltools</title>
+<title>Estimate derivatives of values in covidcast_signal data frame — estimate_deriv • modeltools</title>
 
 
 <!-- jquery -->
@@ -39,7 +39,7 @@
 
 
 
-<meta property="og:title" content="Estimate derivatives of values in <code>covidcast_signal</code> data frame — estimate_deriv" />
+<meta property="og:title" content="Estimate derivatives of values in covidcast_signal data frame — estimate_deriv" />
 <meta property="og:description" content="Estimates derivatives of the values in a covidcast_signal data frame, using
 a local (in time) linear regression or smoothing spline. (When multiple issue
 dates are present, only the latest issue is considered.)  See the
@@ -84,7 +84,7 @@ for examples." />
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -116,7 +116,7 @@ for examples." />
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/cmu-delphi/covidcast/tree/main/R-packages/modeltools">
-    <span class="fab fa fab fa-github fa-lg"></span>
+    <span class="fab fa-github fa-lg"></span>
      
   </a>
 </li>
@@ -142,19 +142,19 @@ for examples." />
     <p>Estimates derivatives of the values in a <code>covidcast_signal</code> data frame, using
 a local (in time) linear regression or smoothing spline. (When multiple issue
 dates are present, only the latest issue is considered.)  See the
-<a href='https://cmu-delphi.github.io/covidcast/modeltools/articles/estimate-deriv.html'>estimating derivatives vignette</a>
+<a href='https://cmu-delphi.github.io/covidcast/modeltoolsR/articles/estimate-deriv.html'>estimating derivatives vignette</a>
 for examples.</p>
     </div>
 
-    <pre class="usage"><span class='fu'>estimate_deriv</span>(
-  <span class='no'>x</span>,
-  <span class='kw'>method</span> <span class='kw'>=</span> <span class='fu'><a href='https://rdrr.io/r/base/c.html'>c</a></span>(<span class='st'>"lin"</span>, <span class='st'>"ss"</span>, <span class='st'>"tf"</span>),
-  <span class='kw'>n</span> <span class='kw'>=</span> <span class='fl'>14</span>,
-  <span class='kw'>col_name</span> <span class='kw'>=</span> <span class='st'>"deriv"</span>,
-  <span class='kw'>keep_obj</span> <span class='kw'>=</span> <span class='fl'>FALSE</span>,
-  <span class='kw'>deriv</span> <span class='kw'>=</span> <span class='fl'>1</span>,
-  <span class='no'>...</span>
-)</pre>
+    <pre class="usage"><span class='fu'>estimate_deriv</span><span class='op'>(</span>
+  <span class='va'>x</span>,
+  method <span class='op'>=</span> <span class='fu'><a href='https://rdrr.io/r/base/c.html'>c</a></span><span class='op'>(</span><span class='st'>"lin"</span>, <span class='st'>"ss"</span>, <span class='st'>"tf"</span><span class='op'>)</span>,
+  n <span class='op'>=</span> <span class='fl'>14</span>,
+  col_name <span class='op'>=</span> <span class='st'>"deriv"</span>,
+  keep_obj <span class='op'>=</span> <span class='cn'>FALSE</span>,
+  deriv <span class='op'>=</span> <span class='fl'>1</span>,
+  <span class='va'>...</span>
+<span class='op'>)</span></pre>
 
     <h2 class="hasAnchor" id="arguments"><a class="anchor" href="#arguments"></a>Arguments</h2>
     <table class="ref-arguments">
@@ -232,7 +232,7 @@ estimation function (<code><a href='https://rdrr.io/r/stats/lsfit.html'>stats::l
 set of arguments is allowed (and are internally distributed as appropriate
 to <code><a href='https://rdrr.io/pkg/genlasso/man/trendfilter.html'>genlasso::trendfilter()</a></code>, <code><a href='https://rdrr.io/pkg/genlasso/man/cv.trendfilter.html'>genlasso::cv.trendfilter()</a></code>, and
 <code><a href='https://rdrr.io/pkg/genlasso/man/coef.genlasso.html'>genlasso::coef.genlasso()</a></code>):</p>
-<dl'>
+<dl>
 <dt><code>ord</code></dt><dd><p>Order of piecewise polynomial for the trend filtering fit,
 default is 2.</p></dd>
 <dt><code>maxsteps</code></dt><dd><p>Maximum number of steps to take in the solution path before
@@ -264,7 +264,7 @@ rule, respectively). Default is 8 when <code>cv = FALSE</code>, and "1se" when <
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.1.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.6.1.</p>
 </div>
 
       </footer>

--- a/docs/modeltoolsR/reference/index.html
+++ b/docs/modeltoolsR/reference/index.html
@@ -79,7 +79,7 @@
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -111,7 +111,7 @@
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/cmu-delphi/covidcast/tree/main/R-packages/modeltools">
-    <span class="fab fa fab fa-github fa-lg"></span>
+    <span class="fab fa-github fa-lg"></span>
      
   </a>
 </li>
@@ -213,7 +213,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.1.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.6.1.</p>
 </div>
 
       </footer>

--- a/docs/modeltoolsR/reference/pct_change.html
+++ b/docs/modeltoolsR/reference/pct_change.html
@@ -6,7 +6,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>Compute percentage change of values in <code>covidcast_signal</code> data frame — pct_change • modeltools</title>
+<title>Compute percentage change of values in covidcast_signal data frame — pct_change • modeltools</title>
 
 
 <!-- jquery -->
@@ -39,7 +39,7 @@
 
 
 
-<meta property="og:title" content="Compute percentage change of values in <code>covidcast_signal</code> data frame — pct_change" />
+<meta property="og:title" content="Compute percentage change of values in covidcast_signal data frame — pct_change" />
 <meta property="og:description" content="Computes the percentage change of the values in a covidcast_signal data
 frame. (When multiple issue dates are present, only the latest issue is
 considered.)  See the percentage change vignette
@@ -83,7 +83,7 @@ for examples." />
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -115,7 +115,7 @@ for examples." />
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/cmu-delphi/covidcast/tree/main/R-packages/modeltools">
-    <span class="fab fa fab fa-github fa-lg"></span>
+    <span class="fab fa-github fa-lg"></span>
      
   </a>
 </li>
@@ -140,11 +140,11 @@ for examples." />
     <div class="ref-description">
     <p>Computes the percentage change of the values in a <code>covidcast_signal</code> data
 frame. (When multiple issue dates are present, only the latest issue is
-considered.)  See the <a href='https://cmu-delphi.github.io/covidcast/modeltools/articles/pct-change.html'>percentage change vignette</a>
+considered.)  See the <a href='https://cmu-delphi.github.io/covidcast/modeltoolsR/articles/pct-change.html'>percentage change vignette</a>
 for examples.</p>
     </div>
 
-    <pre class="usage"><span class='fu'>pct_change</span>(<span class='no'>x</span>, <span class='kw'>n</span> <span class='kw'>=</span> <span class='fl'>14</span>, <span class='kw'>col_name</span> <span class='kw'>=</span> <span class='st'>"pct_change"</span>)</pre>
+    <pre class="usage"><span class='fu'>pct_change</span><span class='op'>(</span><span class='va'>x</span>, n <span class='op'>=</span> <span class='fl'>14</span>, col_name <span class='op'>=</span> <span class='st'>"pct_change"</span><span class='op'>)</span></pre>
 
     <h2 class="hasAnchor" id="arguments"><a class="anchor" href="#arguments"></a>Arguments</h2>
     <table class="ref-arguments">
@@ -189,7 +189,7 @@ to the <code>col_name</code> argument, containing the percentage change values.<
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.1.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.6.1.</p>
 </div>
 
       </footer>

--- a/docs/modeltoolsR/reference/quantgen_forecaster.html
+++ b/docs/modeltoolsR/reference/quantgen_forecaster.html
@@ -6,7 +6,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>Simple quantile autoregressive forecaster based on <code>quantgen</code> — quantgen_forecaster • modeltools</title>
+<title>Simple quantile autoregressive forecaster based on quantgen — quantgen_forecaster • modeltools</title>
 
 
 <!-- jquery -->
@@ -39,7 +39,7 @@
 
 
 
-<meta property="og:title" content="Simple quantile autoregressive forecaster based on <code>quantgen</code> — quantgen_forecaster" />
+<meta property="og:title" content="Simple quantile autoregressive forecaster based on quantgen — quantgen_forecaster" />
 <meta property="og:description" content="A simple quantile autoregressive forecaster based on quantgen, to be used
 with evalcast, via evalcast::get_predictions(). See the quantgen forecast vignette
 for examples." />
@@ -82,7 +82,7 @@ for examples." />
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -114,7 +114,7 @@ for examples." />
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/cmu-delphi/covidcast/tree/main/R-packages/modeltools">
-    <span class="fab fa fab fa-github fa-lg"></span>
+    <span class="fab fa-github fa-lg"></span>
      
   </a>
 </li>
@@ -138,29 +138,29 @@ for examples." />
 
     <div class="ref-description">
     <p>A simple quantile autoregressive forecaster based on <code>quantgen</code>, to be used
-with <code>evalcast</code>, via <code><a href='https://rdrr.io/pkg/evalcast/man/get_predictions.html'>evalcast::get_predictions()</a></code>. See the <a href='https://cmu-delphi.github.io/covidcast/modeltools/articles/quantgen-forecast.html'>quantgen forecast vignette</a>
+with <code>evalcast</code>, via <code><a href='https://rdrr.io/pkg/evalcast/man/get_predictions.html'>evalcast::get_predictions()</a></code>. See the <a href='https://cmu-delphi.github.io/covidcast/modeltoolsR/articles/quantgen-forecast.html'>quantgen forecast vignette</a>
 for examples.</p>
     </div>
 
-    <pre class="usage"><span class='fu'>quantgen_forecaster</span>(
-  <span class='no'>df</span>,
-  <span class='no'>forecast_date</span>,
-  <span class='no'>signals</span>,
-  <span class='no'>incidence_period</span>,
-  <span class='no'>ahead</span>,
-  <span class='no'>geo_type</span>,
-  <span class='kw'>n</span> <span class='kw'>=</span> <span class='fl'>4</span> * <span class='fu'><a href='https://rdrr.io/r/base/ifelse.html'>ifelse</a></span>(<span class='no'>incidence_period</span> <span class='kw'>==</span> <span class='st'>"day"</span>, <span class='fl'>7</span>, <span class='fl'>1</span>),
-  <span class='kw'>lags</span> <span class='kw'>=</span> <span class='fl'>0</span>,
-  <span class='kw'>tau</span> <span class='kw'>=</span> <span class='kw pkg'>modeltools</span><span class='kw ns'>::</span><span class='no'><a href='covidhub_probs.html'>covidhub_probs</a></span>,
-  <span class='kw'>transform</span> <span class='kw'>=</span> <span class='kw'>NULL</span>,
-  <span class='kw'>inv_trans</span> <span class='kw'>=</span> <span class='kw'>NULL</span>,
-  <span class='kw'>featurize</span> <span class='kw'>=</span> <span class='kw'>NULL</span>,
-  <span class='kw'>noncross</span> <span class='kw'>=</span> <span class='fl'>FALSE</span>,
-  <span class='kw'>noncross_points</span> <span class='kw'>=</span> <span class='fu'><a href='https://rdrr.io/r/base/c.html'>c</a></span>(<span class='st'>"all"</span>, <span class='st'>"test"</span>, <span class='st'>"train"</span>),
-  <span class='kw'>cv_type</span> <span class='kw'>=</span> <span class='fu'><a href='https://rdrr.io/r/base/c.html'>c</a></span>(<span class='st'>"forward"</span>, <span class='st'>"random"</span>),
-  <span class='kw'>verbose</span> <span class='kw'>=</span> <span class='fl'>FALSE</span>,
-  <span class='no'>...</span>
-)</pre>
+    <pre class="usage"><span class='fu'>quantgen_forecaster</span><span class='op'>(</span>
+  <span class='va'>df</span>,
+  <span class='va'>forecast_date</span>,
+  <span class='va'>signals</span>,
+  <span class='va'>incidence_period</span>,
+  <span class='va'>ahead</span>,
+  <span class='va'>geo_type</span>,
+  n <span class='op'>=</span> <span class='fl'>4</span> <span class='op'>*</span> <span class='fu'><a href='https://rdrr.io/r/base/ifelse.html'>ifelse</a></span><span class='op'>(</span><span class='va'>incidence_period</span> <span class='op'>==</span> <span class='st'>"day"</span>, <span class='fl'>7</span>, <span class='fl'>1</span><span class='op'>)</span>,
+  lags <span class='op'>=</span> <span class='fl'>0</span>,
+  tau <span class='op'>=</span> <span class='fu'>modeltools</span><span class='fu'>::</span><span class='va'><a href='covidhub_probs.html'>covidhub_probs</a></span>,
+  transform <span class='op'>=</span> <span class='cn'>NULL</span>,
+  inv_trans <span class='op'>=</span> <span class='cn'>NULL</span>,
+  featurize <span class='op'>=</span> <span class='cn'>NULL</span>,
+  noncross <span class='op'>=</span> <span class='cn'>FALSE</span>,
+  noncross_points <span class='op'>=</span> <span class='fu'><a href='https://rdrr.io/r/base/c.html'>c</a></span><span class='op'>(</span><span class='st'>"all"</span>, <span class='st'>"test"</span>, <span class='st'>"train"</span><span class='op'>)</span>,
+  cv_type <span class='op'>=</span> <span class='fu'><a href='https://rdrr.io/r/base/c.html'>c</a></span><span class='op'>(</span><span class='st'>"forward"</span>, <span class='st'>"random"</span><span class='op'>)</span>,
+  verbose <span class='op'>=</span> <span class='cn'>FALSE</span>,
+  <span class='va'>...</span>
+<span class='op'>)</span></pre>
 
     <h2 class="hasAnchor" id="arguments"><a class="anchor" href="#arguments"></a>Arguments</h2>
     <table class="ref-arguments">
@@ -168,7 +168,7 @@ for examples.</p>
     <tr>
       <th>df</th>
       <td><p>Data frame of signal values to use for forecasting, of the format
-that is returned by <code><a href='https://rdrr.io/pkg/covidcast/man/covidcast_signals.html'>covidcast::covidcast_signals()</a></code>.</p></td>
+that is returned by <code><a href='https://cmu-delphi.github.io/covidcast/covidcastR/reference/covidcast_signals.html'>covidcast::covidcast_signals()</a></code>.</p></td>
     </tr>
     <tr>
       <th>forecast_date</th>
@@ -280,7 +280,7 @@ then predictions are made at the earliest possible forecast date after this
 training period. We march forward one time point at a time and repeat. In
 either case ("random" or "forward"), the loss function used for computing
 validation error is quantile regression loss (read the documentation for
-<code><a href='https://rdrr.io/pkg/quantgen/man/cv_quantile_lasso.html'>quantgen::cv_quantile_lasso()</a></code> for more details); and the final quantile
+<code>quantgen::cv_quantile_lasso()</code> for more details); and the final quantile
 model is refit on the full training set using the validation-optimal tuning
 parameter.</p></td>
     </tr>
@@ -292,12 +292,12 @@ parameter.</p></td>
     <tr>
       <th>...</th>
       <td><p>Additional arguments. Any parameter accepted by
-<code><a href='https://rdrr.io/pkg/quantgen/man/cv_quantile_lasso.html'>quantgen::cv_quantile_lasso()</a></code> (for model training) or by
+<code>quantgen::cv_quantile_lasso()</code> (for model training) or by
 <code>quantgen:::predict.cv_quantile_genlasso()</code> (for model prediction) can be
 passed here. For example, <code>nfolds</code>, for specifying the number of folds used
 in cross-validation, or <code>lambda</code>, for specifying the tuning parameter
 values over which to perform cross-validation (the default allows
-<code><a href='https://rdrr.io/pkg/quantgen/man/cv_quantile_lasso.html'>quantgen::cv_quantile_lasso()</a></code> to set the lambda sequence itself). Note
+<code>quantgen::cv_quantile_lasso()</code> to set the lambda sequence itself). Note
 that fixing a single tuning parameter value (such as <code>lambda = 0</code>)
 effectively disables cross-validation and fits a quantile model at the
 given tuning parameter value (here unregularized quantile autoregression).</p></td>
@@ -325,7 +325,7 @@ quantile forecasts for that location and ahead.</p>
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.1.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.6.1.</p>
 </div>
 
       </footer>

--- a/docs/modeltoolsR/reference/slide_by_geo.html
+++ b/docs/modeltoolsR/reference/slide_by_geo.html
@@ -6,8 +6,8 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>Slide a function over values in <code>covidcast_signal</code> data frame, grouped by
-<code>geo_value</code> — slide_by_geo • modeltools</title>
+<title>Slide a function over values in covidcast_signal data frame, grouped by
+geo_value — slide_by_geo • modeltools</title>
 
 
 <!-- jquery -->
@@ -40,8 +40,8 @@
 
 
 
-<meta property="og:title" content="Slide a function over values in <code>covidcast_signal</code> data frame, grouped by
-<code>geo_value</code> — slide_by_geo" />
+<meta property="og:title" content="Slide a function over values in covidcast_signal data frame, grouped by
+geo_value — slide_by_geo" />
 <meta property="og:description" content="Slides a given function over the values in a  covidcast_signal data frame,
 grouped by geo_value. (When multiple issue dates are present, only the
 latest issue is considered.) See the getting started guide
@@ -85,7 +85,7 @@ for examples." />
       <ul class="nav navbar-nav">
         <li>
   <a href="../index.html">
-    <span class="fas fa fas fa-home fa-lg"></span>
+    <span class="fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -117,7 +117,7 @@ for examples." />
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/cmu-delphi/covidcast/tree/main/R-packages/modeltools">
-    <span class="fab fa fab fa-github fa-lg"></span>
+    <span class="fab fa-github fa-lg"></span>
      
   </a>
 </li>
@@ -143,18 +143,18 @@ for examples." />
     <div class="ref-description">
     <p>Slides a given function over the values in a  <code>covidcast_signal</code> data frame,
 grouped by <code>geo_value</code>. (When multiple issue dates are present, only the
-latest issue is considered.) See the <a href='https://cmu-delphi.github.io/covidcast/modeltools/articles/modeltools.html'>getting started guide</a>
+latest issue is considered.) See the <a href='https://cmu-delphi.github.io/covidcast/modeltoolsR/articles/modeltools.html'>getting started guide</a>
 for examples.</p>
     </div>
 
-    <pre class="usage"><span class='fu'>slide_by_geo</span>(
-  <span class='no'>x</span>,
-  <span class='no'>slide_fun</span>,
-  <span class='kw'>n</span> <span class='kw'>=</span> <span class='fl'>14</span>,
-  <span class='kw'>col_name</span> <span class='kw'>=</span> <span class='st'>"slide_value"</span>,
-  <span class='kw'>col_type</span> <span class='kw'>=</span> <span class='fu'><a href='https://rdrr.io/r/base/c.html'>c</a></span>(<span class='st'>"dbl"</span>, <span class='st'>"int"</span>, <span class='st'>"lgl"</span>, <span class='st'>"chr"</span>, <span class='st'>"list"</span>),
-  <span class='no'>...</span>
-)</pre>
+    <pre class="usage"><span class='fu'>slide_by_geo</span><span class='op'>(</span>
+  <span class='va'>x</span>,
+  <span class='va'>slide_fun</span>,
+  n <span class='op'>=</span> <span class='fl'>14</span>,
+  col_name <span class='op'>=</span> <span class='st'>"slide_value"</span>,
+  col_type <span class='op'>=</span> <span class='fu'><a href='https://rdrr.io/r/base/c.html'>c</a></span><span class='op'>(</span><span class='st'>"dbl"</span>, <span class='st'>"int"</span>, <span class='st'>"lgl"</span>, <span class='st'>"chr"</span>, <span class='st'>"list"</span><span class='op'>)</span>,
+  <span class='va'>...</span>
+<span class='op'>)</span></pre>
 
     <h2 class="hasAnchor" id="arguments"><a class="anchor" href="#arguments"></a>Arguments</h2>
     <table class="ref-arguments">
@@ -217,7 +217,7 @@ to the <code>col_name</code> argument, containing the function values.</p>
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.5.1.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.6.1.</p>
 </div>
 
       </footer>


### PR DESCRIPTION
covidcast/modeltools -> covidcast/modeltoolsR in the roxygen in 4 functions. Required rebuilding roxygen and pkgdown.