### PR TITLE
Make fips_to_name faster.

### DIFF
--- a/R-packages/covidcast/NEWS.md
+++ b/R-packages/covidcast/NEWS.md
@@ -1,3 +1,12 @@
+# covidcast 0.4.1
+
+Released TODO.
+
+## Minor changes
+
+- Geographic lookup functions, such as `fips_to_name()` or `name_to_cbsa()`, are
+  now much faster when given input vectors with many duplicate values.
+
 # covidcast 0.4.0
 
 Released January 13, 2021.

--- a/R-packages/covidcast/R/utils.R
+++ b/R-packages/covidcast/R/utils.R
@@ -153,11 +153,15 @@ fips_to_name = function(code, ignore.case = FALSE, perl = FALSE, fixed = FALSE,
                         ties_method = c("first", "all")) {
   # Leave states in county_census (so we can find state fips)
   df = covidcast::county_census # %>% dplyr::filter(COUNTY != 0)
-
+  
+  # Avoid calling grep_lookup more times than necessary
+  unique_codes = unique(code)
   # Now perform the grep-based look up
-  grep_lookup(key = code, keys = df$FIPS, values = df$CTYNAME,
-              ignore.case = ignore.case, perl = perl, fixed = fixed,
-              ties_method = ties_method)
+  out = grep_lookup(key = unique_codes, keys = df$FIPS, values = df$CTYNAME,
+                    ignore.case = ignore.case, perl = perl, fixed = fixed,
+                    ties_method = ties_method)
+  # Return a vector of same length as code
+  out[match(code, unique_codes)]
 }
 
 #' @rdname fips_to_name

--- a/R-packages/covidcast/tests/testthat/test-geo_utils.R
+++ b/R-packages/covidcast/tests/testthat/test-geo_utils.R
@@ -1,5 +1,3 @@
-suppressPackageStartupMessages(library(covidcast))
-
 test_that("name_to_fips", {
   # Basic function
   expect_equal(name_to_fips("Allegheny"),
@@ -23,4 +21,23 @@ test_that("fips_to_name", {
                c("42003" = "Allegheny County"))
   expect_equal(fips_to_name("42000"),
                c("42000" = "Pennsylvania"))
+
+  # Repeats in vector
+  expect_equal(fips_to_name(c("42003", "42003")),
+               c("42003" = "Allegheny County",
+                 "42003" = "Allegheny County"))
+
+  # Request all ties
+  expect_equal(fips_to_name("4213", ties_method = "all"),
+               list(c("42131" = "Wyoming County",
+                      "42133" = "York County")))
+
+  # Correct matching of multiple ties
+  expect_equal(fips_to_name(c("4213", "4019"), ties_method = "all"),
+               list(c("42131" = "Wyoming County",
+                      "42133" = "York County"),
+                    c("04019" = "Pima County",
+                      "24019" = "Dorchester County",
+                      "34019" = "Hunterdon County",
+                      "54019" = "Fayette County")))
 })


### PR DESCRIPTION
This is to address #418.  The idea is to pass `grep_lookup()` a vector of the unique elements of the fips vector.

In the issue referenced above, I gave a small example that took over 30 seconds.  The same example is now about 20 times faster:

```
dat <- covidcast_signal(data_source = "safegraph", 
                         signal = "restaurants_visit_prop",
                         start_day = "2020-12-13", 
                         end_day = "2021-01-13",
                         geo_type = "county")

system.time({a <- fips_to_name(dat$geo_value)})
# user  system elapsed 
# 1.685   0.007   1.697 
```