### PR TITLE
Add geo_type column to predictions_cards so evaluate_predictions()  doesn't need to guess

### DIFF
--- a/R-packages/evalcast/R/evaluate.R
+++ b/R-packages/evalcast/R/evaluate.R
@@ -135,7 +135,7 @@ get_covidcast_data <- function(predictions_cards,
   assert_that(length(incidence_period) == 1,
               msg = "All predictions cards should have the same incidence
                      period.")
-  geo_type <- unique(predictions_card$geo_type)
+  geo_type <- unique(predictions_cards$geo_type)
   assert_that(length(geo_type) == 1,
               msg = "All predictions cards should have the same geo_type.")
 

--- a/R-packages/evalcast/R/evaluate.R
+++ b/R-packages/evalcast/R/evaluate.R
@@ -135,12 +135,9 @@ get_covidcast_data <- function(predictions_cards,
   assert_that(length(incidence_period) == 1,
               msg = "All predictions cards should have the same incidence
                      period.")
-  geo_type_len <- predictions_cards %>%
-    mutate(type_len = nchar(geo_value)) %>%
-    distinct(type_len)
-  assert_that(nrow(geo_type_len) == 1,
+  geo_type <- unique(predictions_card$geo_type)
+  assert_that(length(geo_type) == 1,
               msg = "All predictions cards should have the same geo_type.")
-  geo_type <- ifelse(geo_type_len$type_len == 2L, "state", "county")
 
   unique_ahead <- select(predictions_cards, .data$ahead) %>%
                     distinct() %>%

--- a/R-packages/evalcast/R/get_predictions.R
+++ b/R-packages/evalcast/R/get_predictions.R
@@ -157,6 +157,7 @@ get_predictions_single_date <- function(forecaster,
       forecast_date = forecast_date,
       data_source = signals$data_source[1],
       signal = signals$signal[1],
+      geo_type = geo_type,
       target_end_date = get_target_period(forecast_date, 
                                           incidence_period, ahead)$end,
       incidence_period = incidence_period) 


### PR DESCRIPTION
Resolves #433

May break compatibility with predictions_cards created before this commit (because they don't have a geo_type() column); new predictions_cards (generated by get_predictions()) will have the necessary column.