### PR TITLE
properly cast factor to numeric

### DIFF
--- a/R-packages/modeltools/R/quantgen.R
+++ b/R-packages/modeltools/R/quantgen.R
@@ -267,7 +267,8 @@ quantgen_forecaster = function(df, forecast_date, signals, incidence_period,
                    names_to = "quantile",
                    values_to = "value") %>%
       mutate(quantile = as.numeric(quantile),
-             value = as.numeric(value),
+             # https://stackoverflow.com/questions/3418128/how-to-convert-a-factor-to-integer-numeric-without-loss-of-information
+             value = as.numeric(levels(value))[value],
              ahead = a)
     
     # TODO: allow train_obj to be appended to forecaster's output. This would


### PR DESCRIPTION
Calling as.numeric() on a factor variable of real numbers, as happens here: https://github.com/cmu-delphi/covidcast/blob/main/R-packages/modeltools/R/quantgen.R#L270 has undefined behavior.  In some systems, the coercion goes through as expected.  In others, the level codes are returned instead.  

The fix ensures that we always obtain the factor values, not the factor level codes.

Reference: https://stackoverflow.com/questions/3418128/how-to-convert-a-factor-to-integer-numeric-without-loss-of-information
