### PR TITLE
scale_by_forecaster behavior

### DIFF
--- a/R-packages/evalcast/R/scale_by_forecaster.R
+++ b/R-packages/evalcast/R/scale_by_forecaster.R
@@ -47,7 +47,7 @@ scale_by_forecaster <- function(score_card,
     for (var in score_cols){
         base_values <- filter(score_card,
                               .data$forecaster == base_forecaster_name)[[var]]
-        if (any(base_values <= 0)) {
+        if (any(base_values == 0) & !is.na(base_values)) {
             warning("scale_by_forecaster will divide by zero in column ", var)
         }
     }

--- a/R-packages/evalcast/R/scale_by_forecaster.R
+++ b/R-packages/evalcast/R/scale_by_forecaster.R
@@ -47,14 +47,14 @@ scale_by_forecaster <- function(score_card,
     for (var in score_cols){
         base_values <- filter(score_card,
                               .data$forecaster == base_forecaster_name)[[var]]
-        if (!all(base_values > 0)) {
+        if (any(base_values <= 0)) {
             warning("scale_by_forecaster will divide by zero in column ", var)
         }
     }
 
     df_list <- map(score_cols, function(var) {
         normalized_card <- score_card %>% 
-            select(c(id_cols, var)) %>% 
+            select(all_of(c(id_cols, var))) %>% 
             pivot_wider(names_from = "forecaster", 
                         names_prefix = var, 
                         values_from = var) %>% 

--- a/R-packages/evalcast/R/scale_by_forecaster.R
+++ b/R-packages/evalcast/R/scale_by_forecaster.R
@@ -57,7 +57,11 @@ scale_by_forecaster <- function(score_card,
             select(all_of(c(id_cols, var))) %>% 
             pivot_wider(names_from = "forecaster", 
                         names_prefix = var, 
-                        values_from = var) %>% 
+                        values_from = var) %>%
+            # for some reason, we fail to scale cols after the baseline
+            # so we move to the end
+            relocate(!!sym(paste0(var, base_forecaster_name)), 
+                     .after = last_col()) %>% 
             mutate(across(starts_with(var), ~ .x /
                             !!sym(paste0(var, base_forecaster_name)))) %>%
             pivot_longer(cols = starts_with(var), 


### PR DESCRIPTION
In the R check, there are a few warnings that this avoids.

* But more importantly, for some reason, scaling seems to ignore any columns that come after the `base_forecaster` in the `df_list`. So we move it to the end. I don't understand why this is the case.