### PR TITLE
Allow filtering by designation when retrieving forecaster names

### DIFF
--- a/R-packages/evalcast/R/get_covidhub_predictions.R
+++ b/R-packages/evalcast/R/get_covidhub_predictions.R
@@ -289,25 +289,37 @@ get_covidhub_forecast_dates <- function(forecaster_name) {
 #' List all COVID forecast models available
 #'
 #' Utility function to list all forecasters submitting COVID-19 forecasts to
-#' the [COVID 19 Forecast Hub](http://covid19forecasthub.org/). 
+#' the [COVID 19 Forecast Hub](http://covid19forecasthub.org/).
 #'
-#' @param repo character strinng either "zoltar" indicating the 
-#' [Zoltar](https://zoltardata.com) Forecast Archive or "covid19forecast_repo"
-#' which lists those available at the 
-#' [Reich Lab](https://github.com/reichlab/covid19-forecast-hub)
-#' Github submission repo.
-#'
-#' @return character vector of all available forecasters
+#' @param repo character string either "zoltar" indicating the
+#'   [Zoltar](https://zoltardata.com) Forecast Archive or "covid19forecast_repo"
+#'   which lists those available at the
+#'   [Reich Lab](https://github.com/reichlab/covid19-forecast-hub)
+#'   Github submission repo.
+#' @param designations vector of character strings representing acceptable
+#'   designation types for models. If `"*"` (the default), models of all
+#'   designations will be returned. See
+#'   [Reich Lab's Documentation](https://github.com/reichlab/covid19-forecast-hub/blob/master/data-processed/METADATA.md#team_model_designation)
+#'   for allowed designations and their meanings.
+#' @return character vector of all available forecasters matching given criteria
 #' @export
 #'
 #'
 get_covidhub_forecaster_names <- function(
-  repo = c("zoltar", "covid19forecast_repo")) {
-  
-  repo <- match.arg(repo, c("zoltar","covid19forecast_repo"))
-  if (repo == "covid19forecast_repo") repo = "remote_hub_repo"
-  
-  covidHubUtils::get_all_models(source = repo)
+  repo = c("zoltar", "covid19forecast_repo"),
+  designations = "*") {
+
+  if (identical(designation, "*")) {
+    repo <- match.arg(repo, c("zoltar", "covid19forecast_repo"))
+    if (repo == "covid19forecast_repo") repo <- "remote_hub_repo"
+    forecaster_names <- covidHubUtils::get_all_models(source = repo)
+  } else {
+    models <- covidHubUtils::get_model_designations(source = "zoltar")
+    forecaster_names <- models %>%
+                         filter(designation %in% designations) %>%
+                         pull(model)
+  }
+  return(forecaster_names)
 }
 
 covidhub_probs <- function() {

--- a/R-packages/evalcast/man/get_covidhub_forecaster_names.Rd
+++ b/R-packages/evalcast/man/get_covidhub_forecaster_names.Rd
@@ -4,17 +4,26 @@
 \alias{get_covidhub_forecaster_names}
 \title{List all COVID forecast models available}
 \usage{
-get_covidhub_forecaster_names(repo = c("zoltar", "covid19forecast_repo"))
+get_covidhub_forecaster_names(
+  repo = c("zoltar", "covid19forecast_repo"),
+  designations = "*"
+)
 }
 \arguments{
-\item{repo}{character strinng either "zoltar" indicating the
+\item{repo}{character string either "zoltar" indicating the
 \href{https://zoltardata.com}{Zoltar} Forecast Archive or "covid19forecast_repo"
 which lists those available at the
 \href{https://github.com/reichlab/covid19-forecast-hub}{Reich Lab}
 Github submission repo.}
+
+\item{designations}{vector of character strings representing acceptable
+designation types for models. If \code{"*"} (the default), models of all
+designations will be returned. See
+\href{https://github.com/reichlab/covid19-forecast-hub/blob/master/data-processed/METADATA.md#team_model_designation}{Reich Lab's Documentation}
+for allowed designations and their meanings.}
 }
 \value{
-character vector of all available forecasters
+character vector of all available forecasters matching given criteria
 }
 \description{
 Utility function to list all forecasters submitting COVID-19 forecasts to


### PR DESCRIPTION
Allow filtering by designation when retrieving forecaster names

Reich Lab allows forecasts to be designated as [different types](https://github.com/reichlab/covid19-forecast-hub/blob/master/data-processed/METADATA.md#team_model_designation). Importantly, Reich Lab have stated that models not designated as "primary" will not be evaluated, so these designations are an indication of how forecasting groups expect their forecasts to be judged. This PR allows users to retrieve model names based on the designation.