### PR TITLE
Trim down arguments in `evalcast::get_predictions()`

### DIFF
--- a/R-packages/evalcast/man-roxygen/signals-template.R
+++ b/R-packages/evalcast/man-roxygen/signals-template.R
@@ -1,16 +1,15 @@
-#' @param signals Tibble with columns `data_source` and `signal` that specifies
-#'   which variables from the COVIDcast API will be used by `forecaster`. Each
-#'   row of `signals` represents a separate signal, and first row is taken to be
-#'   the response. If using `incidence_period = "epiweek"`, the response should
-#'   be something for which summing daily values over an epiweek makes sense
-#'   (e.g., counts or proportions but not log(counts) or log(proportions)).
-#'   Available data sources and signals are documented in the [COVIDcast signal
+#' @param signals Tibble specifying which variables from the COVIDcast API will be downloaded and passed along to `forecaster`.
+#'   Each row of `signals` represents a separate variable to be downloaded.  Available data
+#'   sources, signals, and geo resolutions are documented in the [COVIDcast signal
 #'   documentation](https://cmu-delphi.github.io/delphi-epidata/api/covidcast_signals.html).
-#'   An optional column `start_day` can also be included. This can be a Date
-#'   object or string in the form "YYYY-MM-DD", indicating the earliest date of
-#'   data needed from that data source. Importantly, `start_day` can also be a
-#'   function (represented as a list column) that takes a forecast date and
-#'   returns a start date for model training (again, Date object or string in
-#'   the form "YYYY-MM-DD"). The latter is useful when the start date should be
-#'   computed dynamically from the forecast date (e.g., when `forecaster` only
-#'   trains on the most recent 4 weeks of data).
+#'   We expect the tibble to have the following columns:
+#'   \enumerate{
+#'       \item `data_source`:  name of the source of the signal
+#'       \item `signal`:  name of the signal
+#'       \item `geo_type`:  geo resolution at which to pull the data
+#'       \item `start_day` (optional):  date on which to start downloading the signal.  Can be
+#'           represented as a Date, string in "YYYY-MM-DD" format, or as a function of a Date or 
+#'           string.  The latter is useful when the start date should be computed dynamically from
+#'           the forecast date (e.g., when `forecaster` only trains on the most recent 4 weeks of 
+#'           data).
+#'   }

--- a/R-packages/evalcast/man/baseline_forecaster.Rd
+++ b/R-packages/evalcast/man/baseline_forecaster.Rd
@@ -22,21 +22,20 @@ baseline_forecaster(
 indicating date on which forecasts will be made about some period (e.g.,
 epiweek). For example, if \code{forecast_date = "2020-05-11"}, \code{incidence_period = "day"}, and \code{ahead = 3}, then, we'd be making forecasts for "2020-05-14".}
 
-\item{signals}{Tibble with columns \code{data_source} and \code{signal} that specifies
-which variables from the COVIDcast API will be used by \code{forecaster}. Each
-row of \code{signals} represents a separate signal, and first row is taken to be
-the response. If using \code{incidence_period = "epiweek"}, the response should
-be something for which summing daily values over an epiweek makes sense
-(e.g., counts or proportions but not log(counts) or log(proportions)).
-Available data sources and signals are documented in the \href{https://cmu-delphi.github.io/delphi-epidata/api/covidcast_signals.html}{COVIDcast signal documentation}.
-An optional column \code{start_day} can also be included. This can be a Date
-object or string in the form "YYYY-MM-DD", indicating the earliest date of
-data needed from that data source. Importantly, \code{start_day} can also be a
-function (represented as a list column) that takes a forecast date and
-returns a start date for model training (again, Date object or string in
-the form "YYYY-MM-DD"). The latter is useful when the start date should be
-computed dynamically from the forecast date (e.g., when \code{forecaster} only
-trains on the most recent 4 weeks of data).}
+\item{signals}{Tibble specifying which variables from the COVIDcast API will be downloaded and passed along to \code{forecaster}.
+Each row of \code{signals} represents a separate variable to be downloaded.  Available data
+sources, signals, and geo resolutions are documented in the \href{https://cmu-delphi.github.io/delphi-epidata/api/covidcast_signals.html}{COVIDcast signal documentation}.
+We expect the tibble to have the following columns:
+\enumerate{
+\item \code{data_source}:  name of the source of the signal
+\item \code{signal}:  name of the signal
+\item \code{geo_type}:  geo resolution at which to pull the data
+\item \code{start_day} (optional):  date on which to start downloading the signal.  Can be
+represented as a Date, string in "YYYY-MM-DD" format, or as a function of a Date or
+string.  The latter is useful when the start date should be computed dynamically from
+the forecast date (e.g., when \code{forecaster} only trains on the most recent 4 weeks of
+data).
+}}
 
 \item{incidence_period}{String indicating the incidence period, either
 "epiweek" or "day".}

--- a/R-packages/evalcast/man/get_predictions.Rd
+++ b/R-packages/evalcast/man/get_predictions.Rd
@@ -10,13 +10,11 @@ get_predictions(
   signals,
   forecast_dates,
   incidence_period,
-  ahead,
-  geo_type,
   apply_corrections = NULL,
   signal_aggregation = c("list", "wide", "long"),
   signal_aggregation_dt = NULL,
   as_of_override = function(forecast_date) forecast_date,
-  ...
+  forecaster_args = list()
 )
 }
 \arguments{
@@ -27,37 +25,26 @@ ahead. If your forecaster produces point forecasts, then set \code{quantile=NA}.
 
 \item{name_of_forecaster}{String indicating name of the forecaster.}
 
-\item{signals}{Tibble with columns \code{data_source} and \code{signal} that specifies
-which variables from the COVIDcast API will be used by \code{forecaster}. Each
-row of \code{signals} represents a separate signal, and first row is taken to be
-the response. If using \code{incidence_period = "epiweek"}, the response should
-be something for which summing daily values over an epiweek makes sense
-(e.g., counts or proportions but not log(counts) or log(proportions)).
-Available data sources and signals are documented in the \href{https://cmu-delphi.github.io/delphi-epidata/api/covidcast_signals.html}{COVIDcast signal documentation}.
-An optional column \code{start_day} can also be included. This can be a Date
-object or string in the form "YYYY-MM-DD", indicating the earliest date of
-data needed from that data source. Importantly, \code{start_day} can also be a
-function (represented as a list column) that takes a forecast date and
-returns a start date for model training (again, Date object or string in
-the form "YYYY-MM-DD"). The latter is useful when the start date should be
-computed dynamically from the forecast date (e.g., when \code{forecaster} only
-trains on the most recent 4 weeks of data).}
+\item{signals}{Tibble specifying which variables from the COVIDcast API will be downloaded and passed along to \code{forecaster}.
+Each row of \code{signals} represents a separate variable to be downloaded.  Available data
+sources, signals, and geo resolutions are documented in the \href{https://cmu-delphi.github.io/delphi-epidata/api/covidcast_signals.html}{COVIDcast signal documentation}.
+We expect the tibble to have the following columns:
+\enumerate{
+\item \code{data_source}:  name of the source of the signal
+\item \code{signal}:  name of the signal
+\item \code{geo_type}:  geo resolution at which to pull the data
+\item \code{start_day} (optional):  date on which to start downloading the signal.  Can be
+represented as a Date, string in "YYYY-MM-DD" format, or as a function of a Date or
+string.  The latter is useful when the start date should be computed dynamically from
+the forecast date (e.g., when \code{forecaster} only trains on the most recent 4 weeks of
+data).
+}}
 
 \item{forecast_dates}{Vector of Date objects (or strings of the form
 "YYYY-MM-DD") indicating dates on which forecasts will be made.}
 
 \item{incidence_period}{String indicating the incidence period, either
 "epiweek" or "day".}
-
-\item{ahead}{Vector of (one or more) integers. How many epiweeks/days ahead
-are you forecasting? If \code{incidence_period = "epiweek"} and forecast_date is
-Sunday or Monday, then \code{ahead = 1} means the epiweek that includes the
-forecast date; if \code{forecast_date} falls on a Tuesday through Saturday, then
-it is the following epiweek. If \code{incidence_period = "day"}, then \code{ahead = 1} means the day after forecast date.}
-
-\item{geo_type}{String indicating geographical type, such as "county", or
-"state". See the \href{https://cmu-delphi.github.io/delphi-epidata/api/covidcast_geography.html}{COVIDcast Geographic Coding documentation}
-for available options.}
 
 \item{apply_corrections}{an optional function that applies data corrections
 to the signals. Input is a data frame or list as returned as
@@ -86,10 +73,7 @@ You can override this functionality, though we strongly advise you do so
 with care, by passing a function of a single forecast_date here. The
 function should return a date.}
 
-\item{...}{Additional named arguments to be passed to \code{forecaster()}}
-
-\item{geo_values}{Vector or list of locations whose data will be passed to
-\code{forecaster}. The default, "*", fetches all that is available in the API.}
+\item{forecaster_args}{List of forecaster-specific arguments to pass to \code{forecaster()}}
 }
 \value{
 Long data frame of forecasts with a class of \code{predictions_cards}.
@@ -116,9 +100,9 @@ baby_predictions = get_predictions(
   tibble::tibble(
     data_source=c("jhu-csse", "usa-facts"),
     signal = c("deaths_incidence_num","confirmed_incidence_num"),
-    start_day="2020-08-15"), 
-  "2020-10-01","epiweek", 1:4, 
-  "state", "mi", signal_aggregation="long")
+    start_day="2020-08-15",
+    geo_type = "state"), 
+  "2020-10-01","epiweek", signal_aggregation="long")
 }
 
 }

--- a/R-packages/evalcast/tests/testthat/test-predictions.R
+++ b/R-packages/evalcast/tests/testthat/test-predictions.R
@@ -44,16 +44,15 @@ test_that("get_predictions works", {
 
     signals <- tibble(data_source = "jhu-csse",
                       signal = c("deaths_incidence_num", "confirmed_incidence_num"),
-                      start_day = as.Date("2020-01-01"))
+                      start_day = as.Date("2020-01-01"),
+                      geo_type = c("state", "county"))
     forecast_dates <- as.Date(c("2020-01-01", "2020-01-02"))
 
     pcard <- get_predictions(mock_forecaster,
                              name_of_forecaster = "fake",
                              signals = signals,
                              forecast_dates = forecast_dates,
-                             incidence_period = "epiweek",
-                             ahead = 3,
-                             geo_type = "state")
+                             incidence_period = "epiweek")
 
     expect_called(mock_download_signal, 4)
     expect_equal(mock_args(mock_download_signal),
@@ -69,7 +68,7 @@ test_that("get_predictions works", {
                            start_day = as.Date("2020-01-01"),
                            end_day = as.Date("2020-01-01"),
                            as_of = as.Date("2020-01-01"),
-                           geo_type = "state",
+                           geo_type = "county",
                            geo_values = "*"),
                       list(data_source = "jhu-csse",
                            signal = "deaths_incidence_num",
@@ -83,23 +82,17 @@ test_that("get_predictions works", {
                            start_day = as.Date("2020-01-01"),
                            end_day = as.Date("2020-01-02"),
                            as_of = as.Date("2020-01-02"),
-                           geo_type = "state",
+                           geo_type = "county",
                            geo_values = "*"))
     )
     expect_called(mock_forecaster, 2)
     expect_equal(mock_args(mock_forecaster),
                  list(list(fake_downloaded_signals,
                            as.Date("2020-01-01"),
-                           signals,
-                           "epiweek",
-                           3,
-                           "state"),
+                           list()),
                       list(fake_downloaded_signals,
                            as.Date("2020-01-02"),
-                           signals,
-                           "epiweek",
-                           3,
-                           "state")))
+                           list())))
     expect_equal(colnames(pcard),
       c("ahead", "geo_value", "quantile", "value", "forecaster", "forecast_date", "data_source",
         "signal", "target_end_date", "incidence_period"))
@@ -141,30 +134,17 @@ test_that("get_predictions works when forecaster has additional arguments", {
                              signals = signals,
                              forecast_dates = forecast_dates,
                              incidence_period = "epiweek",
-                             ahead = 3,
-                             geo_type = "state",
-                             forecaster_arg1 = 1,
-                             forecaster_arg2 = "2")
+                             forecaster_args = list(a = 1, b = "2"))
 
     expect_called(mock_download_signal, 4)
     expect_called(mock_forecaster, 2)
     expect_equal(mock_args(mock_forecaster),
                  list(list(fake_downloaded_signals,
                            as.Date("2020-01-01"),
-                           signals,
-                           "epiweek",
-                           3,
-                           "state",
-                           forecaster_arg1 = 1,
-                           forecaster_arg2 = "2"),
+                           list(a = 1, b = "2")),
                       list(fake_downloaded_signals,
                            as.Date("2020-01-02"),
-                           signals,
-                           "epiweek",
-                           3,
-                           "state",
-                           forecaster_arg1 = 1,
-                           forecaster_arg2 = "2")))
+                           list(a = 1, b = "2"))))
     expect_equal(colnames(pcard),
       c("ahead", "geo_value", "quantile", "value", "forecaster", "forecast_date", "data_source",
         "signal", "target_end_date", "incidence_period"))
@@ -181,7 +161,7 @@ test_that("get_predictions works when forecaster has additional arguments", {
   })
 })
 
-test_that("no start_day within signals raises warning but works", {
+test_that("no start_day within signals works", {
   # Set up mocks for the following functions:
   # - `evalcast::download_signals()` to avoid dependencies on the covidcast API.
   # - the forecaster to avoid dependencies on its internal prediction algorithm.
@@ -195,28 +175,38 @@ test_that("no start_day within signals raises warning but works", {
 
     signals_no_start_day <- tibble(
                               data_source = "jhu-csse",
-                              signal = c("deaths_incidence_num", "confirmed_incidence_num"))
+                              signal = c("deaths_incidence_num", "confirmed_incidence_num"),
+                              geo_type = "state")
     forecast_dates <- as.Date(c("2020-01-01"))
 
-    expect_warning(
-      pcard <- get_predictions(mock_forecaster,
-                               name_of_forecaster = "fake",
-                               signals = signals_no_start_day,
-                               forecast_dates = forecast_dates,
-                               incidence_period = "epiweek",
-                               ahead = 2,
-                               geo_type = "state"),
-      "Unknown or uninitialised column: `start_day`.")
+    pcard <- get_predictions(mock_forecaster,
+                              name_of_forecaster = "fake",
+                              signals = signals_no_start_day,
+                              forecast_dates = forecast_dates,
+                              incidence_period = "epiweek")
 
     expect_called(mock_download_signal, 2)
+    expect_equal(mock_args(mock_download_signal),
+                 list(list(data_source = "jhu-csse",
+                           signal = "deaths_incidence_num",
+                           start_day = NULL,
+                           end_day = as.Date("2020-01-01"),
+                           as_of = as.Date("2020-01-01"),
+                           geo_type = "state",
+                           geo_values = "*"),
+                      list(data_source = "jhu-csse",
+                           signal = "confirmed_incidence_num",
+                           start_day = NULL,
+                           end_day = as.Date("2020-01-01"),
+                           as_of = as.Date("2020-01-01"),
+                           geo_type = "state",
+                           geo_values = "*"))
+    )
     expect_called(mock_forecaster, 1)
     expect_equal(mock_args(mock_forecaster),
                  list(list(fake_downloaded_signals,
                            as.Date("2020-01-01"),
-                           signals_no_start_day,
-                           "epiweek",
-                           2,
-                           "state")))
+                           list())))
     expect_equal(colnames(pcard),
       c("ahead", "geo_value", "quantile", "value", "forecaster", "forecast_date", "data_source",
         "signal", "target_end_date", "incidence_period"))
@@ -252,6 +242,7 @@ test_that("start_day function within signals works", {
     signals_with_start_day_fn <- tibble(
                                   data_source = "jhu-csse",
                                   signal = c("deaths_incidence_num", "confirmed_incidence_num"),
+                                  geo_type = "state",
                                   start_day = list(function(forecast_date) forecast_date - 10)
                                  )
     forecast_dates <- as.Date(c("2020-12-11", "2020-12-12"))
@@ -260,29 +251,47 @@ test_that("start_day function within signals works", {
                              name_of_forecaster = "fake",
                              signals = signals_with_start_day_fn,
                              forecast_dates = forecast_dates,
-                             incidence_period = "epiweek",
-                             ahead = 2,
-                             geo_type = "state")
+                             incidence_period = "epiweek")
 
     expect_called(mock_download_signal, 4)
+    expect_equal(mock_args(mock_download_signal),
+                 list(list(data_source = "jhu-csse",
+                           signal = "deaths_incidence_num",
+                           start_day = as.Date("2020-12-01"),
+                           end_day = as.Date("2020-12-11"),
+                           as_of = as.Date("2020-12-11"),
+                           geo_type = "state",
+                           geo_values = "*"),
+                      list(data_source = "jhu-csse",
+                           signal = "confirmed_incidence_num",
+                           start_day = as.Date("2020-12-01"),
+                           end_day = as.Date("2020-12-11"),
+                           as_of = as.Date("2020-12-11"),
+                           geo_type = "state",
+                           geo_values = "*"),
+                      list(data_source = "jhu-csse",
+                           signal = "deaths_incidence_num",
+                           start_day = as.Date("2020-12-02"),
+                           end_day = as.Date("2020-12-12"),
+                           as_of = as.Date("2020-12-12"),
+                           geo_type = "state",
+                           geo_values = "*"),
+                      list(data_source = "jhu-csse",
+                           signal = "confirmed_incidence_num",
+                           start_day = as.Date("2020-12-02"),
+                           end_day = as.Date("2020-12-12"),
+                           as_of = as.Date("2020-12-12"),
+                           geo_type = "state",
+                           geo_values = "*"))
+    )
     expect_called(mock_forecaster, 2)
     expect_equal(mock_args(mock_forecaster),
                  list(list(fake_downloaded_signals,
                            as.Date("2020-12-11"),
-                           tibble(data_source = "jhu-csse",
-                                  signal = c("deaths_incidence_num", "confirmed_incidence_num"),
-                                  start_day = as.Date("2020-12-01")),
-                           "epiweek",
-                           2,
-                           "state"),
+                           list()),
                       list(fake_downloaded_signals,
                            as.Date("2020-12-12"),
-                           tibble(data_source = "jhu-csse",
-                                  signal = c("deaths_incidence_num", "confirmed_incidence_num"),
-                              start_day = as.Date("2020-12-02")),
-                           "epiweek",
-                           2,
-                           "state")))
+                           list())))
     expect_equal(colnames(pcard),
       c("ahead", "geo_value", "quantile", "value", "forecaster", "forecast_date", "data_source",
         "signal", "target_end_date", "incidence_period"))
@@ -326,29 +335,17 @@ test_that("start_day function and date mix within signals works", {
                              name_of_forecaster = "fake",
                              signals = signals_with_start_day_fn,
                              forecast_dates = forecast_dates,
-                             incidence_period = "epiweek",
-                             ahead = 2,
-                             geo_type = "state")
+                             incidence_period = "epiweek")
 
     expect_called(mock_download_signal, 4)
     expect_called(mock_forecaster, 2)
     expect_equal(mock_args(mock_forecaster),
                  list(list(fake_downloaded_signals,
                            as.Date("2020-12-11"),
-                           tibble(data_source = "jhu-csse",
-                                  signal = c("deaths_incidence_num", "confirmed_incidence_num"),
-                                  start_day = as.Date(c("2020-11-07", "2020-12-01"))),
-                           "epiweek",
-                           2,
-                           "state"),
+                           list()),
                       list(fake_downloaded_signals,
                            as.Date("2020-12-12"),
-                           tibble(data_source = "jhu-csse",
-                                  signal = c("deaths_incidence_num", "confirmed_incidence_num"),
-                                  start_day = as.Date(c("2020-11-07", "2020-12-02"))),
-                           "epiweek",
-                           2,
-                           "state")))
+                           list())))
     expect_equal(colnames(pcard),
       c("ahead", "geo_value", "quantile", "value", "forecaster", "forecast_date", "data_source",
         "signal", "target_end_date", "incidence_period"))


### PR DESCRIPTION
Change the signature of `evalcast::get_predictions()` to allow for more flexibility of specifying data retrieval and to minimize the set of arguments passed to the forecaster.   Specifically:

- Remove `ahead` entirely from calls to `get_predictions()`
- Move `geo_type` from an explicit, separate argument to a column in `signals`
- Replace the `...` arguments with an explicit `forecaster_args` list of arguments

Since the calls to the forecasters no longer reflect some of the internal processing, additional tests have been added to verify that the right arguments are being passed to `download_signal()`