### PR TITLE
export the train/test matrix function

### DIFF
--- a/R-packages/modeltools/DESCRIPTION
+++ b/R-packages/modeltools/DESCRIPTION
@@ -17,8 +17,9 @@ LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.1
 Remotes:
-    github::cmu-delphi/covidcast/R-packages/covidcast@main,
-    github::cmu-delphi/covidcast/R-packages/evalcast@main
+    cmu-delphi/covidcast/R-packages/covidcast@main,
+    cmu-delphi/covidcast/R-packages/evalcast@main
+    ryantibs/quantgen/R-package/quantgen@master,
 Imports:
     assertthat,
     covidcast,
@@ -27,4 +28,5 @@ Imports:
     genlasso,
     slider,
     tidyselect,
-    tidyr
+    tidyr,
+    quantgen

--- a/R-packages/modeltools/R/matrix.R
+++ b/R-packages/modeltools/R/matrix.R
@@ -44,7 +44,6 @@
 #'   ),
 #'   ahead = 2,
 #'   training_window_size = 1)
-#' )
 #' }
 #'
 #' @importFrom tibble tibble

--- a/R-packages/modeltools/R/matrix.R
+++ b/R-packages/modeltools/R/matrix.R
@@ -27,6 +27,7 @@
 #'     \item{`predict_x`}{Matrix of prediction data in the same format as `train_x`.  The
 #'         prediction data contains the most recent `training_window_size` days.}
 #'     \item{`predict_geo_values`}{Vector of `geo_values` corresponding to the rows of `predict_x`.}
+#'     \item{`train_end_date`}{latest `time_value` used in the training period}
 #'     }
 #'
 #' @examples \dontrun{
@@ -49,7 +50,7 @@
 #' @importFrom tibble tibble
 #' @importFrom assertthat assert_that
 #'
-#' @export 
+#' @export
 create_train_and_predict_matrices <- function(lagged_df, ahead, training_window_size) {
     out <- list()
 
@@ -63,7 +64,7 @@ create_train_and_predict_matrices <- function(lagged_df, ahead, training_window_
     train_df <- lagged_df %>%
         select(geo_value, time_value, tidyselect::starts_with("value"))
 
-    # Find the last possible date of training data   
+    # Find the last possible date of training data
     response_end_date <- lagged_df %>%
         select(time_value, tidyselect::starts_with(sprintf("response+%i:", ahead))) %>%
         tidyr::drop_na() %>%
@@ -93,6 +94,7 @@ create_train_and_predict_matrices <- function(lagged_df, ahead, training_window_
     out$predict_geo_values <- lagged_df %>%
         filter(time_value == max(time_value)) %>%
         select(geo_value) %>% pull()
+    out$train_end_date <- train_end_date
 
     return(out)
 }

--- a/R-packages/modeltools/man/create_train_and_predict_matrices.Rd
+++ b/R-packages/modeltools/man/create_train_and_predict_matrices.Rd
@@ -32,6 +32,7 @@ days prior to it.}
 \item{\code{predict_x}}{Matrix of prediction data in the same format as \code{train_x}.  The
 prediction data contains the most recent \code{training_window_size} days.}
 \item{\code{predict_geo_values}}{Vector of \code{geo_values} corresponding to the rows of \code{predict_x}.}
+\item{\code{train_end_date}}{latest \code{time_value} used in the training period}
 }
 }
 \description{

--- a/R-packages/modeltools/man/create_train_and_predict_matrices.Rd
+++ b/R-packages/modeltools/man/create_train_and_predict_matrices.Rd
@@ -53,7 +53,6 @@ create_train_and_predict_matrices(
   ),
   ahead = 2,
   training_window_size = 1)
-)
 }
 
 }


### PR DESCRIPTION
1. added dependency on `quantgen` to the DESCRIPTION.
2. rebuilt the docs to export @sgsmob 's  `create_train_and_predict_matrices()`
3. added `train_end_date` to the output of `create_train_and_predict_matrices()` (useful for cv).