### PR TITLE
Update the condition for epidata in the response

### DIFF
--- a/Python-packages/covidcast-py/covidcast/covidcast.py
+++ b/Python-packages/covidcast-py/covidcast/covidcast.py
@@ -184,6 +184,8 @@ def signal(data_source: str,
         dfs = _fetch_epidata(
             data_source, signal, start_day, end_day, geo_type, geo_values, as_of, issues, lag
         )
+    print(dfs)
+    print(len(dfs))
     if len(dfs) > 0:
         out = pd.concat(dfs)
         out.drop("direction", axis=1, inplace=True)
@@ -419,7 +421,8 @@ def _fetch_epidata(data_source: str,
         # In the too-much-data case, we continue to try putting the truncated
         # data in our results. In the no-data case, skip this day entirely,
         # since there is no "epidata" in the response.
-        if "epidata" in day_data:
+        if day_data.get("epidata"):
+            print(day_data)
             dfs.append(pd.DataFrame.from_dict(day_data["epidata"]))
         cur_day += timedelta(1)
     return dfs
@@ -470,7 +473,7 @@ def _async_fetch_epidata(data_source: str,
             warnings.warn(f"Problem obtaining {data_source} {signal} "
                           f"data on {params['time_values']} "
                           f"for geography '{geo_type}': {day_data['message']}", RuntimeWarning)
-        if "epidata" in day_data:
+        if day_data.get("epidata"):
             dfs.append(pd.DataFrame.from_dict(day_data["epidata"]))
     return dfs
 

--- a/Python-packages/covidcast-py/covidcast/covidcast.py
+++ b/Python-packages/covidcast-py/covidcast/covidcast.py
@@ -184,8 +184,6 @@ def signal(data_source: str,
         dfs = _fetch_epidata(
             data_source, signal, start_day, end_day, geo_type, geo_values, as_of, issues, lag
         )
-    print(dfs)
-    print(len(dfs))
     if len(dfs) > 0:
         out = pd.concat(dfs)
         out.drop("direction", axis=1, inplace=True)
@@ -422,7 +420,6 @@ def _fetch_epidata(data_source: str,
         # data in our results. In the no-data case, skip this day entirely,
         # since there is no "epidata" in the response.
         if day_data.get("epidata"):
-            print(day_data)
             dfs.append(pd.DataFrame.from_dict(day_data["epidata"]))
         cur_day += timedelta(1)
     return dfs

--- a/Python-packages/covidcast-py/tests/test_covidcast.py
+++ b/Python-packages/covidcast-py/tests/test_covidcast.py
@@ -58,7 +58,8 @@ def test_signal(mock_covidcast, mock_metadata):
     assert sort_df(response).equals(sort_df(expected))
 
     # test no df output
-    mock_covidcast.return_value = {"result": -2,
+    mock_covidcast.return_value = {"epidata": [],
+                                   "result": -2,
                                    "message": "no results found"}
     assert not covidcast.signal("source", "signal", geo_values=[])
 


### PR DESCRIPTION
The Flask API is returning `{'epidata': [], 'result': -2, 'message': 'no results'}` instead of `{'result': -2, 'message': 'no results'}`, so this check would pass half the time and lead to downstream problems. Open discussion on the flask/epidata side, but this might be a good robustification regardless.