### PR TITLE
Flip lag parity for python covidcast

### DIFF
--- a/Python-packages/covidcast-py/covidcast/covidcast.py
+++ b/Python-packages/covidcast-py/covidcast/covidcast.py
@@ -290,7 +290,9 @@ def aggregate_signals(signals: list, dt: list = None, join_type: str = "outer") 
 
     Each signal's time value can be shifted for analysis on lagged signals using the ``dt``
     argument, which takes a list of integer days to lag each signal's date. Lagging a signal by +1
-    day means that all the dates get shifted forward by 1 day (e.g. Jan 1 becomes Jan 2).
+    day means that all the dates get shifted backward by 1 day (e.g. Jan 2 becomes Jan 1). For
+    example, if you wanted to see how cases affect deaths in the future, you could lag the deaths
+    by +20 since the Jan 20 value becomes Jan 1.
 
     :param signals: List of DataFrames to join.
     :param dt: List of lags in days for each of the input DataFrames in ``signals``.
@@ -315,7 +317,7 @@ def aggregate_signals(signals: list, dt: list = None, join_type: str = "outer") 
             raise ValueError("Multiple geo_types detected. "
                              "All signals must have the same geo_type to be aggregated.")
 
-        df_c["time_value"] = [day + timedelta(lag) for day in df_c["time_value"]]  # lag dates
+        df_c["time_value"] = [day + timedelta(-lag) for day in df_c["time_value"]]  # lag dates
         df_c.drop(["signal", "data_source", "geo_type"], axis=1, inplace=True)
         df_c.rename(
             columns={j: f"{source}_{sig_type}_{i}_{j}" for j in df_c.columns if j not in join_cols},

--- a/Python-packages/covidcast-py/covidcast/covidcast.py
+++ b/Python-packages/covidcast-py/covidcast/covidcast.py
@@ -291,8 +291,8 @@ def aggregate_signals(signals: list, dt: list = None, join_type: str = "outer") 
     Each signal's time value can be shifted for analysis on lagged signals using the ``dt``
     argument, which takes a list of integer days to lag each signal's date. Lagging a signal by +1
     day means that all the dates get shifted backward by 1 day (e.g. Jan 2 becomes Jan 1). For
-    example, if you wanted to see how cases affect deaths in the future, you could lag the deaths
-    by +20 since the Jan 20 value becomes Jan 1.
+    example, if you wanted to see how cases affect deaths 20 days in the future, you could lag the deaths
+    by +20, causing the Jan 20 value to become Jan 1.
 
     :param signals: List of DataFrames to join.
     :param dt: List of lags in days for each of the input DataFrames in ``signals``.

--- a/Python-packages/covidcast-py/covidcast/covidcast.py
+++ b/Python-packages/covidcast-py/covidcast/covidcast.py
@@ -291,8 +291,8 @@ def aggregate_signals(signals: list, dt: list = None, join_type: str = "outer") 
     Each signal's time value can be shifted for analysis on lagged signals using the ``dt``
     argument, which takes a list of integer days to lag each signal's date. Lagging a signal by +1
     day means that all the dates get shifted backward by 1 day (e.g. Jan 2 becomes Jan 1). For
-    example, if you wanted to see how cases affect deaths 20 days in the future, you could lag the deaths
-    by +20, causing the Jan 20 value to become Jan 1.
+    example, if you wanted to see how cases affect deaths 20 days in the future,
+    you could lag the deaths by +20, causing the Jan 20 value to become Jan 1.
 
     :param signals: List of DataFrames to join.
     :param dt: List of lags in days for each of the input DataFrames in ``signals``.

--- a/Python-packages/covidcast-py/docs/changelog.rst
+++ b/Python-packages/covidcast-py/docs/changelog.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+
+v0.1.5, TODO
+------------
+- When using :py:func:`covidcast.aggregate_signals`, the parity of the ``dt`` argument has been flipped, so positive values
+  now correspond to lags instead of leads. See the function documentation for more information.
+
+
 v0.1.4, February 24, 2021
 -------------------------
 

--- a/Python-packages/covidcast-py/tests/test_covidcast.py
+++ b/Python-packages/covidcast-py/tests/test_covidcast.py
@@ -123,28 +123,27 @@ def test_aggregate_signals():
          "data_source": ["z", "z", "z", "z"]})
     # test 3 signals from 3 sources with outer join
     expected1 = pd.DataFrame(
-        {"geo_value": ["a", "b", "c", "d", "a", "b", "c", "d", "b"],
-         "time_value": [date(2020, 1, 1), date(2020, 1, 1), date(2020, 1, 1), date(2020, 1, 1),
-                        date(2020, 1, 2), date(2020, 1, 2), date(2020, 1, 2), date(2020, 1, 2),
-                        date(2020, 1, 3)],
-         "x_i_0_value": [2, 4, 6, np.nan, 8, np.nan, np.nan, np.nan, np.nan],
-         "y_j_1_value": [1, 3, 5, 7, np.nan, np.nan, np.nan, np.nan, np.nan],
-         "y_j_1_extra_col": ["0", "0", "0", "0", np.nan, np.nan, np.nan, np.nan, np.nan],
-         "z_k_2_value": [np.nan, np.nan, np.nan, np.nan, np.nan, 0.5, 1.5, 2.5, 3.5],
-         "geo_type": ["state"]*9})
+        {"geo_value": ["b", "c", "d", "a", "b", "c", "d", "a"],
+         "time_value": [date(2019, 12, 31), date(2019, 12, 31), date(2019, 12, 31), date(2020, 1, 1),
+                        date(2020, 1, 1), date(2020, 1, 1), date(2020, 1, 1), date(2020, 1, 2)],
+         "x_i_0_value": [np.nan, np.nan, np.nan, 2, 4, 6, np.nan, 8],
+         "y_j_1_value": [np.nan, np.nan, np.nan, 1, 3, 5, 7, np.nan],
+         "y_j_1_extra_col": [np.nan, np.nan, np.nan, "0", "0", "0", "0", np.nan],
+         "z_k_2_value": [0.5, 1.5, 2.5, np.nan, 3.5, np.nan, np.nan, np.nan],
+         "geo_type": ["state"]*8})
     assert covidcast.aggregate_signals(
         [test_input1, test_input2, test_input3], dt=[0, 0, 1]).equals(expected1)
 
-    # test 3 signals from 3 sources with inner join has no intersection
+    # test far signals with inner join has no intersection
     assert covidcast.aggregate_signals(
-        [test_input1, test_input3], dt=[0, 1], join_type="inner").empty
+        [test_input1, test_input3], dt=[0, 3], join_type="inner").empty
 
     # test 2 signals from same source (one lagged) with inner join
     expected2 = pd.DataFrame(
         {"geo_value": ["a"],
-         "time_value": [date(2020, 1, 2)],
-         "x_i_0_value": [8],
-         "x_i_1_value": [2],
+         "time_value": [date(2020, 1, 1)],
+         "x_i_0_value": [2],
+         "x_i_1_value": [8],
          "geo_type": ["state"]})
     assert covidcast.aggregate_signals(
         [test_input1, test_input1], dt=[0, 1], join_type="inner").equals(expected2)
@@ -152,10 +151,10 @@ def test_aggregate_signals():
     # test same signal twice with a lag
     expected3 = pd.DataFrame(
         {"geo_value": ["a", "b", "c", "a", "b", "c", "a"],
-         "time_value": [date(2020, 1, 1), date(2020, 1, 1), date(2020, 1, 1), date(2020, 1, 2),
-                        date(2020, 1, 2), date(2020, 1, 2), date(2020, 1, 3)],
-         "x_i_0_value": [2, 4, 6, 8, np.nan, np.nan, np.nan],
-         "x_i_1_value": [np.nan, np.nan, np.nan, 2, 4, 6, 8],
+         "time_value": [date(2019, 12, 31), date(2019, 12, 31), date(2019, 12, 31), date(2020, 1, 1),
+                        date(2020, 1, 1), date(2020, 1, 1), date(2020, 1, 2)],
+         "x_i_0_value": [np.nan, np.nan, np.nan, 2, 4, 6, 8],
+         "x_i_1_value": [2, 4, 6, 8, np.nan, np.nan, np.nan],
          "geo_type": ["state"]*7})
 
     assert covidcast.aggregate_signals([test_input1, test_input1], dt=[0, 1]).equals(expected3)


### PR DESCRIPTION
Realized R and Python are flipped.

in the below examples, note the 3/1 value.

R:
```
> aggregated = aggregate_signals(list(cases, deaths), dt=list(0,2))
> head(aggregated[order(aggregated$time_value), ])
    geo_value time_value value+0:jhu-csse_confirmed_incidence_prop value+2:jhu-csse_deaths_incidence_prop
213        us 2020-03-01                                 0.0021064                              0.0003009
214        us 2020-03-02                                 0.0069211                              0.0012037
215        us 2020-03-03                                 0.0060184                              0.0003009
216        us 2020-03-04                                 0.0099303                              0.0006018
217        us 2020-03-05                                 0.0231708                              0.0009028
218        us 2020-03-06                                 0.0159487                              0.0012037
> tail(aggregated[order(aggregated$time_value), ])
    geo_value time_value value+0:jhu-csse_confirmed_incidence_prop value+2:jhu-csse_deaths_incidence_prop
130        us 2020-12-27                                  46.82903                              1.0920353
120        us 2020-12-28                                  52.49864                              1.1218263
121        us 2020-12-29                                  60.24400                              1.0375690
122        us 2020-12-30                                  70.28838                              0.6481797
123        us 2020-12-31                                  70.91068                                     NA
131        us 2021-01-01                                  46.22809                                     NA
```

Python pre-PR:
```
In [27]: covidcast.aggregate_signals([cases, deaths], dt=[0,2])[['geo_value', 'time_value', 'jhu-csse_confirmed_incidence_prop_0_value', 'jhu-csse_deaths_incidence_prop_1_value']].head()     
Out[27]: 
  geo_value time_value  jhu-csse_confirmed_incidence_prop_0_value  jhu-csse_deaths_incidence_prop_1_value
0        us 2020-03-01                                   0.002106                                     NaN
1        us 2020-03-02                                   0.006921                                     NaN
2        us 2020-03-03                                   0.006018                                0.000000
3        us 2020-03-04                                   0.009930                                0.001505
4        us 2020-03-05                                   0.023171                                0.000301


In [28]: covidcast.aggregate_signals([cases, deaths], dt=[0,2])[['geo_value', 'time_value', 'jhu-csse_confirmed_incidence_prop_0_value', 'jhu-csse_deaths_incidence_prop_1_value']].tail()     
Out[28]: 
    geo_value time_value  jhu-csse_confirmed_incidence_prop_0_value  jhu-csse_deaths_incidence_prop_1_value
304        us 2020-12-30                                  70.288376                                0.601838
305        us 2020-12-31                                  70.910676                                1.092035
306        us 2021-01-01                                  46.228090                                1.121826
307        us 2021-01-02                                        NaN                                1.037569
308        us 2021-01-03                                        NaN                                0.648180


```

Python with this PR:
```
In [5]: covidcast.aggregate_signals([cases, deaths], dt=[0,2])[['geo_value', 'time_value', 'jhu-csse_confirmed_incidence_prop_0_value', 'jhu-csse_deat
   ...: hs_incidence_prop_1_value']].head()                                                                                                           
Out[5]: 
  geo_value time_value  jhu-csse_confirmed_incidence_prop_0_value  jhu-csse_deaths_incidence_prop_1_value
0        us 2020-02-28                                        NaN                                0.000000
1        us 2020-02-29                                        NaN                                0.001505
2        us 2020-03-01                                   0.002106                                0.000301
3        us 2020-03-02                                   0.006921                                0.001204
4        us 2020-03-03                                   0.006018                                0.000301

In [6]: covidcast.aggregate_signals([cases, deaths], dt=[0,2])[['geo_value', 'time_value', 'jhu-csse_confirmed_incidence_prop_0_value', 'jhu-csse_deat
   ...: hs_incidence_prop_1_value']].tail()                                                                                                           
Out[6]: 
    geo_value time_value  jhu-csse_confirmed_incidence_prop_0_value  jhu-csse_deaths_incidence_prop_1_value
304        us 2020-12-28                                  52.498642                                1.121826
305        us 2020-12-29                                  60.243998                                1.037569
306        us 2020-12-30                                  70.288376                                0.648180
307        us 2020-12-31                                  70.910676                                     NaN
308        us 2021-01-01                                  46.228090                                     NaN

```