### PR TITLE
Clean up downloaded CSVs

### DIFF
--- a/R-packages/evalcast/R/get_covidhub_predictions.R
+++ b/R-packages/evalcast/R/get_covidhub_predictions.R
@@ -407,6 +407,10 @@ get_forecaster_predictions_alt <- function(covidhub_forecaster_name,
   }
   pcards <- filter(pcards, .data$signal %in% !!signal)
   class(pcards) = c("predictions_cards", class(pcards))
+  
+  # Cleanup, delete downloaded CSVs from disk
+  unlink(file.path("data", covidhub_forecaster_name), recursive = TRUE)
+  
   pcards
 }
 


### PR DESCRIPTION
Cleans up downloaded CSVs at the end of `get_forecaster_predictions_alt()` since files are not needed anymore.