### PR TITLE
Support weekly time_type in python package

### DIFF
--- a/Python-packages/covidcast-py/covidcast/covidcast.py
+++ b/Python-packages/covidcast-py/covidcast/covidcast.py
@@ -27,7 +27,8 @@ def signal(data_source: str,
            geo_values: Union[str, Iterable[str]] = "*",
            as_of: date = None,
            issues: Union[date, Tuple[date], List[date]] = None,
-           lag: int = None) -> Union[pd.DataFrame, None]:
+           lag: int = None,
+           time_type: str = "day") -> Union[pd.DataFrame, None]:
     """Download a Pandas data frame for one signal.
 
     Obtains data for selected date ranges for all geographic regions of the
@@ -76,10 +77,12 @@ def signal(data_source: str,
       such as ``"smoothed_cli"``.
     :param start_day: Query data beginning on this date. Provided as a
       ``datetime.date`` object. If ``start_day`` is ``None``, defaults to the
-      first day data is available for this signal.
+      first day data is available for this signal. If time_type == "week", then
+      this is rounded to the epiweek containing the day (i.e. the previous Sunday).
     :param end_day: Query data up to this date, inclusive. Provided as a
       ``datetime.date`` object. If ``end_day`` is ``None``, defaults to the most
-      recent day data is available for this signal.
+      recent day data is available for this signal. If time_type == "week", then
+      this is rounded to the epiweek containing the day (i.e. the previous Sunday).
     :param geo_type: The geography type for which to request this data, such as
       ``"county"`` or ``"state"``. Available types are described in the
       COVIDcast signal documentation. Defaults to ``"county"``.
@@ -89,19 +92,24 @@ def signal(data_source: str,
       ...) of strings.
     :param as_of: Fetch only data that was available on or before this date,
       provided as a ``datetime.date`` object. If ``None``, the default, return
-      the most recent available data.
+      the most recent available data. If time_type == "week", then
+      this is rounded to the epiweek containing the day (i.e. the previous Sunday).
     :param issues: Fetch only data that was published or updated ("issued") on
       these dates. Provided as either a single ``datetime.date`` object,
       indicating a single date to fetch data issued on, or a tuple or list
       specifying (start, end) dates. In this case, return all data issued in
       this range. There may be multiple rows for each observation, indicating
       several updates to its value. If ``None``, the default, return the most
-      recently issued data.
+      recently issued data. If time_type == "week", then these are rounded to
+      the epiweek containing the day (i.e. the previous Sunday).
     :param lag: Integer. If, for example, ``lag=3``, fetch only data that was
       published or updated exactly 3 days after the date. For example, a row
       with ``time_value`` of June 3 will only be included in the results if its
       data was issued or updated on June 6. If ``None``, the default, return the
       most recently issued data regardless of its lag.
+    :param time_type: The temporal resolution to request this data. Most signals
+      are available at the "day" resolution (the default); some are only
+      available at the "week" resolution, representing an MMWR week ("epiweek").
     :returns: A Pandas data frame with matching data, or ``None`` if no data is
       returned. Each row is one observation on one day in one geographic location.
       Contains the following columns:
@@ -119,7 +127,8 @@ def signal(data_source: str,
       ``time_value``
         Contains a `pandas Timestamp object
         <https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Timestamp.html>`_
-        identifying the date this estimate is for.
+        identifying the date this estimate is for. For data with `time_type = "week"`, this
+        is the first day of the corresponding epiweek.
 
       ``issue``
         Contains a `pandas Timestamp object
@@ -178,17 +187,19 @@ def signal(data_source: str,
                              start=start_day, end=end_day))
     if _ASYNC_CALL:
         dfs = _async_fetch_epidata(
-            data_source, signal, start_day, end_day, geo_type, geo_values, as_of, issues, lag
+            data_source, signal, start_day, end_day, geo_type,
+            geo_values, as_of, issues, lag, time_type
         )
     else:
         dfs = _fetch_epidata(
-            data_source, signal, start_day, end_day, geo_type, geo_values, as_of, issues, lag
+            data_source, signal, start_day, end_day, geo_type,
+            geo_values, as_of, issues, lag, time_type
         )
     if len(dfs) > 0:
         out = pd.concat(dfs)
         out.drop("direction", axis=1, inplace=True)
-        out["time_value"] = pd.to_datetime(out["time_value"], format="%Y%m%d")
-        out["issue"] = pd.to_datetime(out["issue"], format="%Y%m%d")
+        out["time_value"] = out["time_value"].apply(lambda x: _parse_datetimes(x, time_type))
+        out["issue"] = out["issue"].apply(lambda x: _parse_datetimes(x, time_type))
         out["geo_type"] = geo_type
         out["data_source"] = data_source
         out["signal"] = signal
@@ -385,7 +396,8 @@ def _fetch_epidata(data_source: str,
                    geo_value: Union[str, Iterable[str]],
                    as_of: date,
                    issues: Union[date, tuple, list],
-                   lag: int) -> Union[pd.DataFrame, None]:
+                   lag: int,
+                   time_type: str = "day") -> Union[pd.DataFrame, None]:
     """Fetch data from Epidata API.
 
     signal() wraps this to support fetching data over a range of dates
@@ -395,13 +407,13 @@ def _fetch_epidata(data_source: str,
     entries.
 
     """
-    as_of_str = _date_to_api_string(as_of) if as_of is not None else None
-    issues_strs = _dates_to_api_strings(issues) if issues is not None else None
+    as_of_str = _date_to_api_string(as_of, time_type) if as_of is not None else None
+    issues_strs = _dates_to_api_strings(issues, time_type) if issues is not None else None
     cur_day = start_day
     dfs = []
     while cur_day <= end_day:
-        day_str = _date_to_api_string(cur_day)
-        day_data = Epidata.covidcast(data_source, signal, time_type="day",
+        day_str = _date_to_api_string(cur_day, time_type)
+        day_data = Epidata.covidcast(data_source, signal, time_type=time_type,
                                      geo_type=geo_type, time_values=day_str,
                                      geo_value=geo_value, as_of=as_of_str,
                                      issues=issues_strs, lag=lag)
@@ -421,7 +433,7 @@ def _fetch_epidata(data_source: str,
         # since there is no "epidata" in the response.
         if "epidata" in day_data:
             dfs.append(pd.DataFrame.from_dict(day_data["epidata"]))
-        cur_day += timedelta(1)
+        cur_day += timedelta(1) if time_type == "day" else timedelta(7)
     return dfs
 
 
@@ -433,7 +445,8 @@ def _async_fetch_epidata(data_source: str,
                          geo_value: Union[str, Iterable[str]],
                          as_of: date,
                          issues: Union[date, tuple, list],
-                         lag: int) -> Union[pd.DataFrame, None]:
+                         lag: int,
+                         time_type: str = "day") -> Union[pd.DataFrame, None]:
     """Fetch data from Epidata API asynchronously.
 
     signal() wraps this to support fetching data over a range of dates
@@ -444,7 +457,8 @@ def _async_fetch_epidata(data_source: str,
     """
     dfs = []
     params = []
-    for day in pd.date_range(start_day, end_day):
+    date_range = pd.date_range(start_day, end_day, freq="D" if time_type == "day" else "W")
+    for day in date_range:
         day_param = {
             "source": "covidcast",
             "data_source": data_source,
@@ -452,12 +466,12 @@ def _async_fetch_epidata(data_source: str,
             "time_type": "day",
             "geo_type": geo_type,
             "geo_value": geo_value,
-            "time_values": _date_to_api_string(day),
+            "time_values": _date_to_api_string(day, time_type),
         }
         if as_of:
-            day_param["as_of"] = _date_to_api_string(as_of)
+            day_param["as_of"] = _date_to_api_string(as_of, time_type)
         if issues:
-            day_param["issues"] = _dates_to_api_strings(issues)
+            day_param["issues"] = _dates_to_api_strings(issues, time_type)
         if lag:
             day_param["lag"] = lag
         params.append(day_param)
@@ -501,14 +515,18 @@ def _signal_metadata(data_source: str,
     return output
 
 
-def _date_to_api_string(date: date) -> str:  # pylint: disable=W0621
-    """Convert a date object to a YYYYMMDD string expected by the API."""
-    return date.strftime("%Y%m%d")
+def _date_to_api_string(date: date, time_type: str = "day") -> str:  # pylint: disable=W0621
+    """Convert a date object to a YYYYMMDD or YYYYMM string expected by the API."""
+    if time_type == "day":
+        date_str = date.strftime("%Y%m%d")
+    elif time_type == "week":
+        date_str = Week.fromdate(date).cdcformat()
+    return date_str
 
 
-def _dates_to_api_strings(dates: Union[date, list, tuple]) -> str:
+def _dates_to_api_strings(dates: Union[date, list, tuple], time_type: str = "day") -> str:
     """Convert a date object, or pair of (start, end) objects, to YYYYMMDD strings."""
     if not isinstance(dates, (list, tuple)):
-        return _date_to_api_string(dates)
+        return _date_to_api_string(dates, time_type)
 
-    return "-".join(_date_to_api_string(date) for date in dates)
+    return "-".join(_date_to_api_string(date, time_type) for date in dates)

--- a/Python-packages/covidcast-py/tests/test_covidcast.py
+++ b/Python-packages/covidcast-py/tests/test_covidcast.py
@@ -331,6 +331,7 @@ def test__signal_metadata(mock_metadata):
 def test__date_to_api_string():
     # since the function just wraps strftime, this is just to ensure the format doesn't change
     assert covidcast._date_to_api_string(date(2020, 4, 2)) == "20200402"
+    assert covidcast._date_to_api_string(date(2020, 4, 2), time_type="week") == "202014"
 
 
 def test__dates_to_api_strings():
@@ -338,3 +339,6 @@ def test__dates_to_api_strings():
     assert covidcast._dates_to_api_strings(date(2020, 4, 2)) == "20200402"
     assert covidcast._dates_to_api_strings([date(2020, 4, 2),
                                             date(2020, 5, 2)]) == "20200402-20200502"
+    assert covidcast._dates_to_api_strings(date(2020, 4, 2), time_type="week") == "202014"
+    assert covidcast._dates_to_api_strings([date(2020, 4, 2),
+                                            date(2020, 5, 2)], time_type="week") == "202014-202018"


### PR DESCRIPTION
(This is a remake of PR #528; time travel is dangerous.)

This is the Python analogue of #380. Adds time_type support to `signal` and `_date_to_api_string` and modifies fetching logic slightly for both async and non-async calls.

A demo call to `nchs-mortality` with my local branch:
```

> remote_signal_name = "nchs-mortality"
> signal_type = "deaths_covid_incidence_num"
> geo_type = "state"
> start_day = date(2021, 1, 1)
> end_day = date(2021, 4, 20)
> df1 = covidcast.signal(remote_signal_name, signal_type, start_day, end_day, geo_type, time_type="week")
> df1 = df1.reset_index().set_index(["geo_value", "time_value"]).sort_index()
> print(df1.index.levels[1])
> print(df1["issue"].unique())
DatetimeIndex(['2020-12-27', '2021-01-03', '2021-01-10', '2021-01-17',
               '2021-01-24', '2021-01-31', '2021-02-07', '2021-02-14',
               '2021-02-21', '2021-02-28', '2021-03-07', '2021-03-14',
               '2021-03-21', '2021-03-28', '2021-04-04', '2021-04-11'],
              dtype='datetime64[ns]', name='time_value', freq=None)
['2021-04-18T00:00:00.000000000' '2021-04-11T00:00:00.000000000'
 '2021-01-24T00:00:00.000000000' '2021-01-31T00:00:00.000000000'
 '2021-02-14T00:00:00.000000000' '2021-02-21T00:00:00.000000000'
 '2021-02-28T00:00:00.000000000' '2021-03-07T00:00:00.000000000'
 '2021-03-14T00:00:00.000000000' '2021-03-21T00:00:00.000000000'
 '2021-03-28T00:00:00.000000000' '2021-04-04T00:00:00.000000000'
 '2021-01-03T00:00:00.000000000' '2021-01-10T00:00:00.000000000']

> remote_signal_name = "nchs-mortality"
> signal_type = "deaths_covid_incidence_num"
> geo_type = "state"
> start_day = date(2021, 1, 1)
> end_day = date(2021, 4, 20)
> issue = date(2021, 2, 14)
> df1 = covidcast.signal(remote_signal_name, signal_type, start_day, end_day, geo_type, time_type="week", issues=issue)
> df1 = df1.reset_index().set_index(["geo_value", "time_value"]).sort_index()
> df1["issue"].unique()
array(['2021-02-14T00:00:00.000000000'], dtype='datetime64[ns]')

> remote_signal_name = "nchs-mortality"
> signal_type = "deaths_covid_incidence_num"
> geo_type = "state"
> start_day = date(2021, 1, 1)
> end_day = date(2021, 4, 20)
> as_of = date(2021, 2, 14)
> df1 = covidcast.signal(remote_signal_name, signal_type, start_day, end_day, geo_type, time_type="week", as_of=as_of)
> df1 = df1.reset_index().set_index(["geo_value", "time_value"]).sort_index()
> df1["issue"].le(pd.to_datetime(as_of)).all()
True