### PR TITLE
Fix `problem_dates` check when fetching actual data from API

### DIFF
--- a/R-packages/evalcast/R/get_target_response.R
+++ b/R-packages/evalcast/R/get_target_response.R
@@ -49,7 +49,7 @@ get_target_response <- function(signals,
                    "forecast dates: ",
                    paste(forecast_dates[problem_dates], collapse = ", "),
                    "."))
-    if (length(problem_dates) == length(forecast_dates)) return(empty_actual())
+    if (sum(problem_dates) == length(forecast_dates)) return(empty_actual())
     out <- out[!problem_dates]
     forecast_dates <- forecast_dates[!problem_dates]
   }

--- a/R-packages/evalcast/R/get_target_response.R
+++ b/R-packages/evalcast/R/get_target_response.R
@@ -52,6 +52,7 @@ get_target_response <- function(signals,
     if (sum(problem_dates) == length(forecast_dates)) return(empty_actual())
     out <- out[!problem_dates]
     forecast_dates <- forecast_dates[!problem_dates]
+    target_periods <- target_periods[!problem_dates, ]
   }
   names(out) <- forecast_dates
   target_periods$forecast_date = lubridate::ymd(forecast_dates)


### PR DESCRIPTION
### Description
Change `problem_dates` check from looking at length of `problem_dates`, which is always the same value and always equal to `forecast_dates`, to looking at the number of `TRUE`s in `problem_dates`. The old version of this check would always be true and always return an empty df if any `problem_dates` existed (if any dates requested from the API didn't return data), neglecting to return the data for the other requested dates.

### Changes
In `get_target_response`,
- Return empty df when the number of `problem_dates` is the same as the number of forecast_dates.
- Subset `target_periods` to only those that had data returned from the API to match length of `out` and `forecast_dates`.