### PR TITLE
Update quantgen dependency folder structure

### DIFF
--- a/R-packages/modeltools/DESCRIPTION
+++ b/R-packages/modeltools/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: modeltools
 Type: Package
-Title: Tools for Building COVID Forecasters and Related Models 
+Title: Tools for Building COVID Forecasters and Related Models
 Version: 0.1.0
 Authors@R:
 	c(
@@ -19,7 +19,7 @@ RoxygenNote: 7.1.1
 Remotes:
     cmu-delphi/covidcast/R-packages/covidcast@main,
     cmu-delphi/covidcast/R-packages/evalcast@main,
-    ryantibs/quantgen/R-package/quantgen@master,
+    ryantibs/quantgen/quantgen@master,
 Imports:
     assertthat,
     covidcast,


### PR DESCRIPTION
[Quantgen](https://github.com/ryantibs/quantgen/tree/master/quantgen) recently reorganized its folder structure, which makes the installation
```
devtools::install_github("cmu-delphi/covidcast", ref="modeltools", subdir="R-packages/modeltools")
```
error out with a 404 when installing the quantgen dependency.

This PR should fix the ref. Tested locally by a manual git clone with
```
devtools::install("src/covidcast/R-packages/modeltools")
```