### PR TITLE
Remove duplicate join in `evaluate_covid_predictions`

### DIFF
--- a/R-packages/evalcast/R/evaluate_predictions.R
+++ b/R-packages/evalcast/R/evaluate_predictions.R
@@ -130,12 +130,10 @@ evaluate_covid_predictions <- function(predictions_cards,
                "ahead")
   actual_data <- get_covidcast_data(predictions_cards, backfill_buffer,
                                     geo_type)
-  predictions_cards <- left_join(predictions_cards,
-                                 actual_data,
-                                 by = grp_vars)
   score_card <- evaluate_predictions(predictions_cards,
                                      actual_data,
-                                     err_measures)
+                                     err_measures,
+                                     grp_vars)
   score_card <- score_card %>%
     relocate(.data$ahead, .data$geo_value, .data$forecaster,
              .data$forecast_date, .data$data_source,


### PR DESCRIPTION
### Description
Currently, truth data is joined on to `predictions_cards` in both `evaluate_covid_predictions`, before calling `evaluate_predictions`, and in `evaluate_predictions`. `evaluate_predictions` is passed separate `actual_data` and doesn't use the truth data contained in `predictions_cards`, so the first join is doing unnecessary work. Remove it, but enforce the same column ordering.

### Changes
- Remove join in `evaluate_covid_predictions` that adds on truth data.
- Pass `grp_vars` to `evaluate_predictions`.