### PR TITLE
Revert "Remove duplicate join in `evaluate_covid_predictions`"

### DIFF
--- a/R-packages/evalcast/R/evaluate_predictions.R
+++ b/R-packages/evalcast/R/evaluate_predictions.R
@@ -130,10 +130,12 @@ evaluate_covid_predictions <- function(predictions_cards,
                "ahead")
   actual_data <- get_covidcast_data(predictions_cards, backfill_buffer,
                                     geo_type)
+  predictions_cards <- left_join(predictions_cards,
+                                 actual_data,
+                                 by = grp_vars)
   score_card <- evaluate_predictions(predictions_cards,
                                      actual_data,
-                                     err_measures,
-                                     grp_vars)
+                                     err_measures)
   score_card <- score_card %>%
     relocate(.data$ahead, .data$geo_value, .data$forecaster,
              .data$forecast_date, .data$data_source,


### PR DESCRIPTION
Reverts cmu-delphi/covidcast#563

Above change causes the forecast eval pipeline to fail with `Error: weighted_interval_score: quantiles must be unique.`. Reverting so we have a working pipeline for next week while I debug.