### PR TITLE
[Testing] Use r2u-ci for evalcast CI

### DIFF
--- a/.github/workflows/r_evalcast_ci.yml
+++ b/.github/workflows/r_evalcast_ci.yml
@@ -27,13 +27,6 @@ jobs:
     defaults:
       run:
         working-directory: R-packages/evalcast/
-    strategy:
-      matrix:
-        include:
-          - {os: macOS-latest}
-          - {os: ubuntu-latest}
-
-    runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/r_evalcast_ci.yml
+++ b/.github/workflows/r_evalcast_ci.yml
@@ -17,11 +17,11 @@ on:
 env:
   USE_BSPM: "true"
   _R_CHECK_FORCE_SUGGESTS_: "false"
-  R_VERSION: 3.5
+  R_VERSION: 4.0
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     defaults:

--- a/.github/workflows/r_evalcast_ci.yml
+++ b/.github/workflows/r_evalcast_ci.yml
@@ -38,12 +38,6 @@ jobs:
           chmod 0755 run.sh
           ./run.sh bootstrap
 
-      - name: Cache R packages
-        uses: actions/cache@v2
-        with:
-          path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-r-${{ env.R_VERSION }}-eval-1-
-
       - name: Dependencies
         run: ./run.sh install_all
 

--- a/.github/workflows/r_evalcast_ci.yml
+++ b/.github/workflows/r_evalcast_ci.yml
@@ -14,16 +14,14 @@ on:
   pull_request:
     branches: [ main, evalcast ]
 
-env:
-  USE_BSPM: "true"
-  _R_CHECK_FORCE_SUGGESTS_: "false"
-  R_VERSION: 4.0
-
 jobs:
   build:
     runs-on: ubuntu-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      USE_BSPM: "true"
+      _R_CHECK_FORCE_SUGGESTS_: "false"
+      R_VERSION: 4.0
     defaults:
       run:
         working-directory: R-packages/evalcast/
@@ -34,9 +32,15 @@ jobs:
       # See https://eddelbuettel.github.io/r-ci/ for more info on below.
       - name: Bootstrap
         run: |
-          curl -OLs https://eddelbuettel.github.io/r-ci/run.sh
+          curl -OLs https://eddelbuettel.github.io/r-ci/
           chmod 0755 run.sh
           ./run.sh bootstrap
+
+      - name: Cache R packages
+        uses: actions/cache@v2
+        with:
+          path: /usr/lib/R/site-library
+          key: ${{ runner.os }}-r-${{ env.R_VERSION }}-eval-1-
 
       - name: Dependencies
         run: ./run.sh install_all

--- a/.github/workflows/r_evalcast_ci.yml
+++ b/.github/workflows/r_evalcast_ci.yml
@@ -36,12 +36,12 @@ jobs:
           chmod 0755 run.sh
           ./run.sh bootstrap
 
-      - name: Cache R packages
-        uses: actions/cache@v2
-        with:
-          path: |
-            /usr/lib/R/site-library
-          key: ${{ runner.os }}-r-${{ env.R_VERSION }}-eval-1-
+      # - name: Cache R packages
+      #   uses: actions/cache@v2
+      #   with:
+      #     path: |
+      #       /usr/lib/R/site-library
+      #     key: ${{ runner.os }}-r-${{ env.R_VERSION }}-eval-1-
 
       - name: Dependencies
         run: ./run.sh install_all

--- a/.github/workflows/r_evalcast_ci.yml
+++ b/.github/workflows/r_evalcast_ci.yml
@@ -21,7 +21,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     defaults:

--- a/.github/workflows/r_evalcast_ci.yml
+++ b/.github/workflows/r_evalcast_ci.yml
@@ -16,12 +16,12 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       USE_BSPM: "true"
       _R_CHECK_FORCE_SUGGESTS_: "false"
-      R_VERSION: 4.0
+      R_VERSION: 3.5
     defaults:
       run:
         working-directory: R-packages/evalcast/

--- a/.github/workflows/r_evalcast_ci.yml
+++ b/.github/workflows/r_evalcast_ci.yml
@@ -32,14 +32,15 @@ jobs:
       # See https://eddelbuettel.github.io/r-ci/ for more info on below.
       - name: Bootstrap
         run: |
-          curl -OLs https://eddelbuettel.github.io/r-ci/
+          curl -OLs https://eddelbuettel.github.io/r-ci/run.sh
           chmod 0755 run.sh
           ./run.sh bootstrap
 
       - name: Cache R packages
         uses: actions/cache@v2
         with:
-          path: /usr/lib/R/site-library
+          path: |
+            /usr/lib/R/site-library
           key: ${{ runner.os }}-r-${{ env.R_VERSION }}-eval-1-
 
       - name: Dependencies

--- a/.github/workflows/r_evalcast_ci.yml
+++ b/.github/workflows/r_evalcast_ci.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-r-eval-1-
+          key: ${{ runner.os }}-r-${{ env.R_VERSION }}-eval-1-
 
       - name: Dependencies
         run: ./run.sh install_all

--- a/.github/workflows/r_evalcast_ci.yml
+++ b/.github/workflows/r_evalcast_ci.yml
@@ -14,6 +14,11 @@ on:
   pull_request:
     branches: [ main, evalcast ]
 
+env:
+  USE_BSPM: "true"
+  _R_CHECK_FORCE_SUGGESTS_: "false"
+  R_VERSION: 3.5
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -24,31 +29,30 @@ jobs:
         working-directory: R-packages/evalcast/
     strategy:
       matrix:
-        r-version: [3.5]
+        include:
+          - {os: macOS-latest}
+          - {os: ubuntu-latest}
+
+    runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up R ${{ matrix.r-version }}
-        uses: r-lib/actions/setup-r@v1
-        with:
-          r-version: ${{ matrix.r-version }}
-      - name: Install linux dependencies  
+
+      # See https://eddelbuettel.github.io/r-ci/ for more info on below.
+      - name: Bootstrap
         run: |
-            sudo apt-get install libcurl4-openssl-dev
-            sudo apt-get install libudunits2-dev
-            sudo apt-get install libgdal-dev
-            sudo apt-get install libicu-dev
+          curl -OLs https://eddelbuettel.github.io/r-ci/run.sh
+          chmod 0755 run.sh
+          ./run.sh bootstrap
+
       - name: Cache R packages
         uses: actions/cache@v2
         with:
           path: ${{ env.R_LIBS_USER }}
           key: ${{ runner.os }}-r-eval-1-
-      - name: Install dependencies
-        run: |
-          install.packages(c("remotes", "rcmdcheck"))
-          remotes::install_deps(dependencies = TRUE)
-        shell: Rscript {0}
-      - name: Check
-        run: |
-          rcmdcheck::rcmdcheck(args = c("--no-manual", "--ignore-vignettes", "--as-cran"), build_args = c("--no-build-vignettes"), error_on = "error")
-        shell: Rscript {0}
+
+      - name: Dependencies
+        run: ./run.sh install_all
+
+      - name: Test
+        run: ./run.sh run_tests


### PR DESCRIPTION
This branch tests the new [PPA r2u](https://eddelbuettel.github.io/r2u/) from [Eddelbuettel](http://dirk.eddelbuettel.com/) and uses it to install R packages in the CI using his handy [r2u-ci](https://eddelbuettel.github.io/r-ci/) scripts. If it works, this could dramatically speed up installation speeds in CI.

- [ ] Make sure that the package caching `${{ env.R_LIBS_USER }}` works (or update it, if it doesn't)