### PR TITLE
Modify xpath to account for changed GH html on file lists

### DIFF
--- a/R-packages/evalcast/R/get_covidhub_predictions.R
+++ b/R-packages/evalcast/R/get_covidhub_predictions.R
@@ -426,7 +426,7 @@ get_forecaster_predictions_alt <- function(covidhub_forecaster_name,
 get_covidhub_forecast_dates <- function(forecaster_name) {
   url <- "https://github.com/reichlab/covid19-forecast-hub/tree/master/data-processed/"
   out <- xml2::read_html(paste0(url, forecaster_name)) %>%
-    rvest::html_nodes(xpath = "//*[@id=\"js-repo-pjax-container\"]/div[2]/div/div/div[3]") %>%
+    rvest::html_nodes(xpath = "//*[@id=\"js-repo-pjax-container\"]/turbo-frame/div/div/div/div[3]") %>%
     rvest::html_text() %>%
     stringr::str_remove_all("\\n") %>%
     stringr::str_match_all(sprintf("(20\\d{2}-\\d{2}-\\d{2})-%s.csv",


### PR DESCRIPTION
This morning, the [forecast eval pipeline](https://github.com/cmu-delphi/forecast-eval/runs/7303389090?check_suite_focus=true) started getting

```
1. error in evaluating the argument 'x' in selecting a method for function 'as_date': error in evaluating the argument 'x' in selecting a method for function 'as_date': subscript out of bounds
```

for every forecaster requested. There have been no code changes on our end for the last several months, which implies a problem with one of the APIs or other non-package dependencies we use.

The errors are coming from [`lubridate` attempting to parse](https://github.com/cmu-delphi/covidcast/blob/60e5fdd72766b21a1ce6ee68ba5b7789f3bc6de7/R-packages/evalcast/R/get_covidhub_predictions.R#L434) dates from data filenames but there not being any dates to parse. It appears that the html of GitHub pages changed slightly so that the existing `xpath` argument doesn't work (no filenames are found).

This PR modifies the `xpath` so that we can read the list of files again.