### PR TITLE
Fix `evalcast:::get_forecast_dates` bug

### DIFF
--- a/R-packages/evalcast/R/get_covidhub_predictions.R
+++ b/R-packages/evalcast/R/get_covidhub_predictions.R
@@ -152,7 +152,7 @@ get_forecast_dates <- function(forecasters,
   forecaster_dates <- vector("list", length = length(forecasters))
   for (i in seq_len(length(forecasters))) {
     forecaster_dates[[i]] <- tryCatch({
-      lubridate::as_date(get_covidhub_forecast_dates(forecasters[i]))
+      lubridate::as_date(get_zoltar_forecast_dates(forecasters[i]))
     },
     error = function(e) cat(sprintf("%i. %s\n", i, e$message))
     )
@@ -228,7 +228,7 @@ get_forecaster_predictions <- function(covidhub_forecaster_name,
   url <- "https://raw.githubusercontent.com/reichlab/covid19-forecast-hub/master/data-processed"
   pcards <- list()
   if (is.null(forecast_dates))
-    forecast_dates <- get_covidhub_forecast_dates(covidhub_forecaster_name)
+    forecast_dates <- get_zoltar_forecast_dates(covidhub_forecaster_name)
   forecast_dates <- as.character(forecast_dates)
   for (forecast_date in forecast_dates) {
     filename <- sprintf("%s/%s/%s-%s.csv",
@@ -316,7 +316,7 @@ get_forecaster_predictions_alt <- function(covidhub_forecaster_name,
 ) {
   url <- "https://raw.githubusercontent.com/reichlab/covid19-forecast-hub/master/data-processed"
   if (is.null(forecast_dates))
-    forecast_dates <- get_covidhub_forecast_dates(covidhub_forecaster_name)
+    forecast_dates <- get_zoltar_forecast_dates(covidhub_forecaster_name)
   forecast_dates <- as.character(forecast_dates)
   # Download files to disk first
   # File layout is data/<covidhub_forecaster_name>/<forecast_date>/data.csv


### PR DESCRIPTION
An alternative approach to the same ends as in #586. 

Probably more long term safe, but maybe moving too fast in deprecating `get_covidhub_forecast_dates`. A more complete version of this work would switch us completely to using zoltr, while putting in the html parse fix, to continue to support code that continues to use `get_covidhub_forecast_dates`. I just don't have the bandwidth to take that on right now, especially since the zoltr get predictions function appears to be broken now.

```r
r$> get_zoltar_predictions("CMU-TimeSeries", forecast_dates = "2022-07-18")
get_token(): POST: https://zoltardata.com/api-token-auth/
get_resource(): GET: https://zoltardata.com/api/projects/
get_resource(): GET: https://zoltardata.com/api/project/44/timezeros/
[1] "Grabbing forecasts from Zoltar..."
Error: POST status was not 200. status_code=400, json_response=Invalid query. error_messages='["target with name not found. name=1 wk ahead inc hosp, valid names=['17 day ahead inc hosp', '17 wk ahead cum death', '17 wk ahead inc death', '18 day ahead cum death', '18 day ahead inc death', '2 wk ahead inc case', '101 day ahead inc hosp', '102 day ahead cum death', '102 day ahead inc death', '102 day ahead inc hosp', '103 day ahead cum death', '16 wk ahead cum death', '16 wk ahead inc death', '17 day ahead cum death', '17 day ahead inc death', '18 day ahead inc hosp', '18 wk ahead cum death', '1 wk ahead inc case', '3 wk ahead inc case', '4 wk ahead inc case', '5 wk ahead inc case', '6 wk ahead inc case', '7 wk ahead inc case', '8 wk ahead inc case', '18 wk ahead inc death', '19 day ahead cum death', '19 day ahead inc death', '19 day ahead inc hosp', '19 wk ahead cum death', '19 wk ahead inc death', '20 day ahead cum death', '20 day ahead inc death', '20 day ahead inc hosp', '20 wk ahead
```

cc @nmdefries @brookslogan for input.