### PR TITLE
Update `evalcast` branch with covidhub xpath fix on `evalcast-forecast-eval`

### DIFF
--- a/R-packages/evalcast/R/get_covidhub_predictions.R
+++ b/R-packages/evalcast/R/get_covidhub_predictions.R
@@ -426,7 +426,7 @@ get_forecaster_predictions_alt <- function(covidhub_forecaster_name,
 get_covidhub_forecast_dates <- function(forecaster_name) {
   url <- "https://github.com/reichlab/covid19-forecast-hub/tree/master/data-processed/"
   out <- xml2::read_html(paste0(url, forecaster_name)) %>%
-    rvest::html_nodes(xpath = "//*[@id=\"js-repo-pjax-container\"]/div[2]/div/div/div[3]") %>%
+    rvest::html_nodes(xpath = "//*[@id=\"js-repo-pjax-container\"]/turbo-frame/div/div/div/div[3]") %>%
     rvest::html_text() %>%
     stringr::str_remove_all("\\n") %>%
     stringr::str_match_all(sprintf("(20\\d{2}-\\d{2}-\\d{2})-%s.csv",


### PR DESCRIPTION
This fix makes `get_covidhub_forecast_dates` and `get_covidhub_forecasts` work again.  It's from #586.  An alternative fix for `get_covidhub_forecasts` is #587, relying on using `get_zoltar_forecast_dates`.

Aside: I think the download caching in the evalcast branch is opt-in (and only concerns `get_predictions`, not fetching predictions, and is fairly robust now I think), so the evalcast branch can probably be used by the forecast eval dashboard.  (Although maybe it's still a good idea to keep this separate branch for stability and consciously update it when needed.  It's a tradeoff.) 