### PR TITLE
Update codeowners for `evalcast`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,7 @@
 /R-packages/data-raw/ @capnrefsmmat  @statsmaths
 
 # evalcast R package
-/R-packages/evalcast/ @jacobbien @dajmcdon
+/R-packages/evalcast/ @nmdefries @brookslogan @dshemetov
 
 # modeltools R package
 /R-packages/modeltools/ @huisaddison @dajmcdon

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,8 +2,8 @@
 * @krivard @capnrefsmmat
 
 # covidcast R package and data generation
-/R-packages/covidcast/ @capnrefsmmat @statsmaths
-/R-packages/data-raw/ @capnrefsmmat  @statsmaths
+/R-packages/covidcast/ @capnrefsmmat
+/R-packages/data-raw/ @capnrefsmmat
 
 # evalcast R package
 /R-packages/evalcast/ @nmdefries @brookslogan @dshemetov
@@ -12,11 +12,11 @@
 /R-packages/modeltools/ @huisaddison @dajmcdon
 
 # covidcast Python package
-/Python-packages/covidcast-py/ @chinandrew @capnrefsmmat @statsmaths
+/Python-packages/covidcast-py/ @chinandrew @capnrefsmmat
 
 # notebooks
-/R-notebooks/  @capolitsch @krivard 
+/R-notebooks/  @krivard
 
 # documentation changes go live instantly on GitHub.io, and hence require their
 # own review
-/docs/  @capnrefsmmat @statsmaths
+/docs/  @capnrefsmmat


### PR DESCRIPTION
Switch from Dan and Jacob, who are no longer active on `evalcast`, to @nmdefries, @dshemetov, and @brookslogan.