### PR TITLE
Drop duplicate truth data join in `evaluate_covid_predictions`

### DIFF
--- a/R-packages/evalcast/R/evaluate_predictions.R
+++ b/R-packages/evalcast/R/evaluate_predictions.R
@@ -129,12 +129,6 @@ evaluate_covid_predictions <- function(predictions_cards,
   assert_that("predictions_cards" %in% class(predictions_cards),
               msg = "predictions_cards must be of class `predictions_cards`")
   geo_type <- match.arg(geo_type)
-  grp_vars <- c("data_source",
-               "signal",
-               "incidence_period",
-               "geo_value",
-               "forecast_date",
-               "ahead")
   actual_data <- get_covidcast_data(predictions_cards, backfill_buffer,
                                     geo_type, offline_signal_dir)
   score_card <- evaluate_predictions(predictions_cards,

--- a/R-packages/evalcast/R/evaluate_predictions.R
+++ b/R-packages/evalcast/R/evaluate_predictions.R
@@ -133,9 +133,6 @@ evaluate_covid_predictions <- function(predictions_cards,
                "ahead")
   actual_data <- get_covidcast_data(predictions_cards, backfill_buffer,
                                     geo_type, offline_signal_dir)
-  predictions_cards <- left_join(predictions_cards,
-                                 actual_data,
-                                 by = grp_vars)
   score_card <- evaluate_predictions(predictions_cards,
                                      actual_data,
                                      err_measures)

--- a/R-packages/evalcast/R/evaluate_predictions.R
+++ b/R-packages/evalcast/R/evaluate_predictions.R
@@ -43,9 +43,13 @@ evaluate_predictions <- function(
   assert_that(is.data.frame(truth_data),
               msg = paste("In evaluate_predictions: `truth_data` must be a
                           data frame"))
+  if ("actual" %in% names(predictions_cards)) {
+    warning("`predictions_cards` already has an `actual` column; this `actual` column will be used and `truth_data` will be ignored.")
+  }
   assert_that("actual" %in% names(truth_data),
               msg = paste("`truth_data` must contain a column named `actual`"))
-  predictions_cards <- left_join(predictions_cards, truth_data)
+  predictions_cards <- left_join(predictions_cards, truth_data,
+                                 by=intersect(colnames(predictions_cards), colnames(truth_data)))
   if (is.null(err_measures) || length(err_measures) == 0) {
     score_card <- predictions_cards
   } else {


### PR DESCRIPTION
### Description
Currently, truth data is joined on to `predictions_cards` in both `evaluate_covid_predictions`, before calling `evaluate_predictions`, and in `evaluate_predictions`. `evaluate_predictions` is passed separate `actual_data` and doesn't use the truth data contained in `predictions_cards`, so the first join is doing unnecessary work.

### Changes
- Remove join in `evaluate_covid_predictions` that adds on truth data.