### PR TITLE
Support Ubuntu 22.04 in CI

### DIFF
--- a/.github/workflows/python_ci.yml
+++ b/.github/workflows/python_ci.yml
@@ -17,7 +17,7 @@ jobs:
         working-directory: Python-packages/covidcast-py/
     strategy:
       matrix:
-        python-version: [3.6]
+        python-version: [3.8]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/r_evalcast_ci.yml
+++ b/.github/workflows/r_evalcast_ci.yml
@@ -24,12 +24,12 @@ jobs:
         working-directory: R-packages/evalcast/
     strategy:
       matrix:
-        r-version: [3.5]
+        r-version: [4.1]
 
     steps:
       - uses: actions/checkout@v2
       - name: Set up R ${{ matrix.r-version }}
-        uses: r-lib/actions/setup-r@v1
+        uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.r-version }}
       - name: Install linux dependencies  


### PR DESCRIPTION
Github Actions' `ubunu-latest` tag has recently [started referring to Ubuntu 22.04](https://github.blog/changelog/2022-12-01-github-actions-larger-runners-using-ubuntu-latest-label-will-now-use-ubuntu-22-04/). The R libraries PPA used by `r-lib/actions/setup-r@v1` (deprecated) doesn't support the newest version of Ubuntu, causing the `evalcast` workflow to fail with `E: The repository 'https://ppa.launchpadcontent.net/cran/travis/ubuntu jammy Release' does not have a Release file.` and `Error: Failed to get R 3.5.3: Failed to get R 3.5.3: Failed to install R`. Switch to `r-lib/actions/setup-r@v2` instead, which does support Ubuntu 22.04.

Also use a recent R version.

This stops with a test failure (`Error: Error: 'eval_forecasts' is not an exported object from 'namespace:scoringutils'`), but that's been an ongoing issue; not going address here.

The Python CI is having a similar problem; the requested python version (3.6) is not available on the new Ubuntu 22.04. Use a newer Python version that is [supported](https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json) (3.7-3.12). This stops with a test failure, but that's been an ongoing issue; not going address here.