### PR TITLE
Update `get_predictions` to not use `bettermc` when `parallel_execution=FALSE`

### DIFF
--- a/R-packages/evalcast/DESCRIPTION
+++ b/R-packages/evalcast/DESCRIPTION
@@ -56,9 +56,8 @@ LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.0
 Remotes:
-  reichlab/zoltr,
-  reichlab/covidHubUtils,
-  epiforecasts/scoringutils
+    reichlab/zoltr,
+    reichlab/covidHubUtils,
 Imports:
     assertthat,
     covidcast,

--- a/R-packages/evalcast/R/evaluate_predictions.R
+++ b/R-packages/evalcast/R/evaluate_predictions.R
@@ -61,7 +61,7 @@ evaluate_predictions <- function(
     score_card <- predictions_cards %>%
       group_by(across(all_of(grp_vars))) %>%
       summarize(!!!err_calls, .groups = "drop") %>%
-      inner_join(predictions_cards, by = grp_vars)
+      inner_join(predictions_cards, by = grp_vars, multiple = "all")
   }
   class(score_card) <- c("score_cards", class(score_card))
   attributes(score_card) <- c(attributes(score_card),

--- a/R-packages/evalcast/R/get_predictions.R
+++ b/R-packages/evalcast/R/get_predictions.R
@@ -126,7 +126,11 @@ get_predictions <- function(forecaster,
     return(preds)
   }
 
-  out <- rlang::inject(bettermc::mclapply(forecast_dates, get_predictions_single_date_, mc.cores = num_cores, !!!additional_mclapply_args)) %>% bind_rows()
+  if (parallel_execution) {
+    out <- rlang::inject(bettermc::mclapply(forecast_dates, get_predictions_single_date_, mc.cores = num_cores, !!!additional_mclapply_args)) %>% bind_rows()
+  } else {
+    out <- lapply(forecast_dates, get_predictions_single_date_) %>% bind_rows()
+  }
 
   # for some reason, `value` gets named and ends up in attr
   names(out$value) <- NULL

--- a/R-packages/evalcast/R/get_predictions.R
+++ b/R-packages/evalcast/R/get_predictions.R
@@ -126,8 +126,10 @@ get_predictions <- function(forecaster,
     return(preds)
   }
 
-  if (parallel_execution) {
+  if (rlang::is_bool(parallel_execution) && parallel_execution == TRUE) {
     out <- rlang::inject(bettermc::mclapply(forecast_dates, get_predictions_single_date_, mc.cores = num_cores, !!!additional_mclapply_args)) %>% bind_rows()
+  } else if (rlang::is_integer(parallel_execution) && parallel_execution > 1L) {
+    out <- rlang::inject(bettermc::mclapply(forecast_dates, get_predictions_single_date_, mc.cores = parallel_execution, !!!additional_mclapply_args)) %>% bind_rows()
   } else {
     out <- lapply(forecast_dates, get_predictions_single_date_) %>% bind_rows()
   }

--- a/R-packages/evalcast/man/get_predictions.Rd
+++ b/R-packages/evalcast/man/get_predictions.Rd
@@ -108,10 +108,11 @@ to \code{forecaster()}. A common use case would be to pass the period ahead
 required component of the forecaster output (see above).}
 
 \item{parallel_execution}{TRUE, FALSE, or a single positive integer. If TRUE,
-uses bettermc::mclapply to execute each forecast date prediction in
-parallel on max number of cores - 1. If FALSE, the code is run on a single
-core. If integer, runs in parallel on that many cores, clipping to the max
-number of detected cores if a greater number is requested.}
+executes each forecast date prediction in parallel on the number of
+detected cores available minus 1. If FALSE, the code is run on a single
+core. If integer, runs in parallel on that many cores, clipping to the
+number of detected cores available if a greater number is requested. Uses
+\code{\link[bettermc:mclapply]{bettermc::mclapply}} for parallelism if using more than one core.}
 
 \item{additional_mclapply_args}{a named list of additional arguments to pass
 to \code{\link[bettermc:mclapply]{bettermc::mclapply}} (besides \code{X}, \code{FUN}, and

--- a/R-packages/evalcast/tests/testthat/test-predictions.R
+++ b/R-packages/evalcast/tests/testthat/test-predictions.R
@@ -1,6 +1,7 @@
 library(mockr)
 library(mockery)
 library(magrittr)
+library(dplyr)
 
 # Create a fake result from the covidcast API as returned by the `evalcast::download_signals()`
 # function.
@@ -10,7 +11,7 @@ create_fake_downloaded_signal <- function(geo_value, data_source, signal) {
          geo_value = geo_value,
          time_value = as.Date(c("2020-01-01", "2020-01-02")),
          issue = as.Date("2020-01-02"),
-         lag = 1L,
+         lag = as.integer(.data$issue - .data$time_value),
          value = c(1, 2),
          stderr = c(0.1, 0.2),
          sample_size = c(2, 2)) 
@@ -438,7 +439,7 @@ create_fake_downloaded_signal_large <- function(geo_value, data_source, signal) 
     geo_value = geo_value,
     time_value = seq(as.Date("2020-01-01"), as.Date("2020-01-31"), by = "days"),
     issue = as.Date("2020-01-31"),
-    lag = 0L,
+    lag = as.integer(.data$issue - .data$time_value),
     value = seq(1, 31),
     stderr = seq(1, 31) * 0.1,
     sample_size = seq(1, 31) * 10,
@@ -450,7 +451,7 @@ test_that("get_predictions on baseline_forecaster works with parallel_execution=
     signal = c("deaths_incidence_num", "confirmed_incidence_num"),
     start_day = "2020-01-01"
   )
-  forecast_dates <- ymd(c("2020-01-30", "2020-01-31"))
+  forecast_dates <- as.Date(c("2020-01-30", "2020-01-31"))
   fake_downloaded_signals <- list(
     create_fake_downloaded_signal_large("in", "jhu-csse", "deaths_incidence_num"),
     create_fake_downloaded_signal_large("nc", "jhu-csse", "confirmed_incidence_num")


### PR DESCRIPTION
- Fixes #599 
- Also addresses a failing test and a [series of new warnings from dplyr==1.1.0 when using joins](https://github.com/tidyverse/dplyr/releases/tag/v1.1.0)