### PR TITLE
Evalcast: move `scoringutils` source to CRAN from Github

### DIFF
--- a/R-packages/evalcast/DESCRIPTION
+++ b/R-packages/evalcast/DESCRIPTION
@@ -56,9 +56,8 @@ LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.0
 Remotes:
-  reichlab/zoltr,
-  reichlab/covidHubUtils,
-  epiforecasts/scoringutils
+    reichlab/zoltr,
+    reichlab/covidHubUtils,
 Imports:
     assertthat,
     covidcast,


### PR DESCRIPTION
We no longer need the latest version of `scoringutils`, so move to a slower-moving version. Merge after #614 because it contains a test fix.