### PR TITLE
covidcast package updates for API keys

### DIFF
--- a/Python-packages/covidcast-py/DEVELOP.md
+++ b/Python-packages/covidcast-py/DEVELOP.md
@@ -51,9 +51,8 @@ When you develop a new package version, there are several steps to consider.
 These are written from the `Python-packages/covidcast-py/` directory:
 
 1. Increment the package version in `setup.py` and in Sphinx's `conf.py`.
-2. Install the requirements needed to build the package and documentation with `make install-requirements`
-3. Rebuild and install the package locally with `make install`
-4. Rebuild the documentation. The documentation lives in `docs/` and is built by
+2. Install the package and its dependencies locally with `make install`
+3. Rebuild the documentation. The documentation lives in `docs/` and is built by
    [Sphinx](https://www.sphinx-doc.org/en/master/), which automatically reads
    the function docstrings and formats them. `docs/index.rst` contains the main
    documentation and the `.. autofunction::` directives insert documentation of
@@ -62,18 +61,16 @@ These are written from the `Python-packages/covidcast-py/` directory:
    To rebuild the documentation, run
 
     ```sh
-    cd docs/
-    make clean
-    make html
+    make sphinx
     ```
 
     and then open `covidcast/docs/covidcast-py/html/index.html` to preview the
     new version.
 
-    If you make changes to `index.rst`, you can simply run `make html` to
+    If you make changes to `index.rst`, you can simply run `make sphinx` to
     rebuild without needing to reinstall the package.
-5. Build the release artifacts with `make build`.
-6. Upload to PyPI. It should be as easy as
+4. Build the release artifacts with `make build`.
+5. Upload to PyPI. It should be as easy as
 
     ```sh
     twine upload dist/covidcast-0.0.9*

--- a/Python-packages/covidcast-py/Makefile
+++ b/Python-packages/covidcast-py/Makefile
@@ -20,6 +20,11 @@ build:
 	python3 setup.py clean
 	python3 setup.py sdist bdist_wheel
 
+sphinx: venv
+	. env/bin/activate; \
+	cd docs; \
+	make html
+
 lint:
 	. env/bin/activate; pylint covidcast/ --rcfile .pylintrc
 	. env/bin/activate; pydocstyle covidcast/
@@ -29,4 +34,5 @@ test:
 	pytest tests/ -W ignore::UserWarning
 
 clean:
+	cd docs && make clean && cd -; \
 	rm -rf env

--- a/Python-packages/covidcast-py/covidcast/__init__.py
+++ b/Python-packages/covidcast-py/covidcast/__init__.py
@@ -12,7 +12,7 @@ Functions:
 
 """
 
-from .covidcast import signal, metadata, aggregate_signals
+from .covidcast import signal, metadata, aggregate_signals, use_api_key
 from .plotting import plot, plot_choropleth, get_geo_df, animate
 from .geography import (fips_to_name, cbsa_to_name, abbr_to_name,
                         name_to_abbr, name_to_cbsa, name_to_fips,

--- a/Python-packages/covidcast-py/covidcast/covidcast.py
+++ b/Python-packages/covidcast-py/covidcast/covidcast.py
@@ -23,16 +23,16 @@ def use_api_key(key):
 
     :param key: String containing the API key for you and/or your group.
 
-    Anyone may access the Epidata API anonymously without providing an API
-    key. Anonymous API access is limited to $RATE_LIMIT with a maximum of two of
+    Anyone may access the Epidata API anonymously without providing an API key.
+    Anonymous API access is currently rate-limited and with a maximum of two of
     the requested parameters having multiple selections (signals, dates, issues,
     regions, etc). To be exempt from these limits, use this function to apply an
     API key to all subsequent queries. You can register for an API key at
-    <TODO:URL>.
+    <https://forms.gle/hkBr5SfQgxguAfEt7>.
 
-    Consult the `API documentation <TODO:URL>`_ for details on our API key
-    policies.
-
+    Consult the `API documentation
+    <https://cmu-delphi.github.io/delphi-epidata/api/api_keys.html>`_
+    for details on our API key policies.
     """
     Epidata.auth = key
 

--- a/Python-packages/covidcast-py/covidcast/covidcast.py
+++ b/Python-packages/covidcast-py/covidcast/covidcast.py
@@ -11,13 +11,30 @@ from epiweeks import Week
 
 from .errors import NoDataWarning
 
-# Point API requests to the AWS endpoint
+# Point API requests to the default endpoint
 Epidata.BASE_URL = "https://api.covidcast.cmu.edu/epidata/api.php"
 
 VALID_GEO_TYPES = {"county", "hrr", "msa", "dma", "state",  "hhs", "nation"}
 
 _ASYNC_CALL = False
 
+def use_api_key(key):
+    """Set the API key to use for all subsequent queries.
+
+    :param key: String containing the API key for you and/or your group.
+
+    Anyone may access the Epidata API anonymously without providing an API
+    key. Anonymous API access is limited to $RATE_LIMIT with a maximum of two of
+    the requested parameters having multiple selections (signals, dates, issues,
+    regions, etc). To be exempt from these limits, use this function to apply an
+    API key to all subsequent queries. You can register for an API key at
+    <TODO:URL>.
+
+    Consult the `API documentation <TODO:URL>`_ for details on our API key
+    policies.
+
+    """
+    Epidata.auth = key
 
 def signal(data_source: str,
            signal: str,  # pylint: disable=W0621

--- a/Python-packages/covidcast-py/docs/changelog.rst
+++ b/Python-packages/covidcast-py/docs/changelog.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+v0.1.6, May _, 2023
+-------------------
+
+- New feature: This package now supports queries that require an API key. Call
+  :py:func:`covidcast.use_api_key` before running fetch functions to
+  authenticate your requests.
+
 v0.1.5, May 11, 2021
 --------------------
 

--- a/Python-packages/covidcast-py/docs/getting_started.rst
+++ b/Python-packages/covidcast-py/docs/getting_started.rst
@@ -104,6 +104,15 @@ May 1st were updated on May 23rd based on new data, giving a ``lag`` of 22 days.
 See the :py:func:`covidcast.signal` documentation for details on the returned
 data frame.
 
+By default, this package submits queries to the API anonymously. If you have an
+API key, you can use it with this package by calling
+:py:func:`covidcast.use_api_key`, then call fetch functions as normal:
+
+>>> covidcast.use_api_key("your_api_key")
+>>> data = covidcast.signal("fb-survey", "smoothed_cli",
+...                         date(2020, 5, 1), date(2020, 5, 7),
+...                         "county")
+
 The API documentation lists each available signal and provides technical details
 on how it is estimated and how its standard error is calculated. In this case,
 for example, the `symptom surveys documentation page

--- a/Python-packages/covidcast-py/docs/getting_started.rst
+++ b/Python-packages/covidcast-py/docs/getting_started.rst
@@ -104,14 +104,17 @@ May 1st were updated on May 23rd based on new data, giving a ``lag`` of 22 days.
 See the :py:func:`covidcast.signal` documentation for details on the returned
 data frame.
 
-By default, this package submits queries to the API anonymously. If you have an
-API key, you can use it with this package by calling
-:py:func:`covidcast.use_api_key`, then call fetch functions as normal:
+.. _api-key-usage:
+.. note ::
 
->>> covidcast.use_api_key("your_api_key")
->>> data = covidcast.signal("fb-survey", "smoothed_cli",
-...                         date(2020, 5, 1), date(2020, 5, 7),
-...                         "county")
+   By default, this package submits queries to the API anonymously. If you have an
+   API key, you can use it with this package by calling
+   :py:func:`covidcast.use_api_key`, then call fetch functions as normal:
+
+       >>> covidcast.use_api_key("your_api_key")
+       >>> data = covidcast.signal("fb-survey", "smoothed_cli",
+       ...                         date(2020, 5, 1), date(2020, 5, 7),
+       ...                         "county")
 
 The API documentation lists each available signal and provides technical details
 on how it is estimated and how its standard error is calculated. In this case,

--- a/Python-packages/covidcast-py/docs/index.rst
+++ b/Python-packages/covidcast-py/docs/index.rst
@@ -31,10 +31,21 @@ To get started, check out :ref:`getting started <getting-started>`.
    notified of package updates, new data sources, corrections, and other
    updates.
 
-.. warning :: If you use data from the COVIDcast Epidata API to power a public
-   product, dashboard, app, or other service, please download the data you need
-   and store it centrally rather than making API requests for every user. Our
-   server resources are limited and cannot support high-volume interactive use.
+.. warning :: By default, this package submits queries to the API
+   anonymously. All the examples in the package documentation are compatible
+   with anonymous use of the API, but `there are some limits on anonymous
+   queries <https://cmu-delphi.github.io/delphi-epidata/api/api_keys.html>`_
+   which do not apply if you use an API key to authenticate your queries. If you
+   regularly or frequently use our system, please consider `registering for a
+   free API key <https://forms.gle/hkBr5SfQgxguAfEt7>`_ even if your usage falls
+   within the anonymous usage limits. API key usage helps us understand who and
+   how others are using our Delphi Epidata API, which may in turn inform our
+   future research, data partnerships, and funding. As we are a research group,
+   our server resources are limited and cannot support high-volume interactive
+   use (with or without an API key). If you use data from the COVIDcast Epidata
+   API to power a public product, dashboard, app, or other service, please
+   download the data you need and store it centrally rather than making API
+   requests for every user.
 
    See also the `COVIDcast Terms of Use
    <https://covidcast.cmu.edu/terms-of-use.html>`_, noting that the data is a

--- a/Python-packages/covidcast-py/docs/index.rst
+++ b/Python-packages/covidcast-py/docs/index.rst
@@ -40,12 +40,14 @@ To get started, check out :ref:`getting started <getting-started>`.
    free API key <https://forms.gle/hkBr5SfQgxguAfEt7>`_ even if your usage falls
    within the anonymous usage limits. API key usage helps us understand who and
    how others are using our Delphi Epidata API, which may in turn inform our
-   future research, data partnerships, and funding. As we are a research group,
-   our server resources are limited and cannot support high-volume interactive
-   use (with or without an API key). If you use data from the COVIDcast Epidata
-   API to power a public product, dashboard, app, or other service, please
-   download the data you need and store it centrally rather than making API
-   requests for every user.
+   future research, data partnerships, and funding. For usage instructions, see
+   :py:func:`covidcast.use_api_key`.
+
+   As we are a research group, our server resources are limited and cannot
+   support high-volume interactive use (with or without an API key). If you use
+   data from the COVIDcast Epidata API to power a public product, dashboard,
+   app, or other service, please download the data you need and store it
+   centrally rather than making API requests for every user.
 
    See also the `COVIDcast Terms of Use
    <https://covidcast.cmu.edu/terms-of-use.html>`_, noting that the data is a

--- a/Python-packages/covidcast-py/docs/signals.rst
+++ b/Python-packages/covidcast-py/docs/signals.rst
@@ -1,7 +1,7 @@
 Fetching Data
 =============
 
-API Keys
+API keys
 --------
 
 .. autofunction:: covidcast.use_api_key

--- a/Python-packages/covidcast-py/docs/signals.rst
+++ b/Python-packages/covidcast-py/docs/signals.rst
@@ -1,6 +1,11 @@
 Fetching Data
 =============
 
+API Keys
+--------
+
+.. autofunction:: covidcast.use_api_key
+
 Signals
 -------
 

--- a/Python-packages/covidcast-py/setup.py
+++ b/Python-packages/covidcast-py/setup.py
@@ -20,7 +20,7 @@ setuptools.setup(
     ],
     python_requires=">=3.6",
     install_requires=[
-        "pandas",
+        "pandas<2",
         "requests",
         "delphi-epidata>=0.0.11",
         "geopandas",

--- a/R-packages/covidcast/R/covidcast.R
+++ b/R-packages/covidcast/R/covidcast.R
@@ -1013,8 +1013,8 @@ covidcast <- function(data_source, signal, time_type, geo_type, time_values,
   }
 
   msg <- "fetch data from API"
-  if (httr::status_code(response) %in% c(429, 401)) {
-    msg <- paste(msg, "anonymously - to register for an API key, visit TODO")
+  if (is.na(auth)) {
+    msg <- paste(msg, "anonymously")
   }
   httr::stop_for_status(response, task = msg)
 

--- a/R-packages/covidcast/vignettes/covidcast.Rmd
+++ b/R-packages/covidcast/vignettes/covidcast.Rmd
@@ -80,6 +80,8 @@ cli <- covidcast_signal(data_source = "fb-survey", signal = "smoothed_cli",
 knitr::kable(head(cli))
 ```
 
+### API keys
+
 By default, this package submits queries to the API anonymously. All the
 examples in the package documentation are compatible with anonymous use of the
 API, but [there are some limits on anonymous

--- a/R-packages/covidcast/vignettes/covidcast.Rmd
+++ b/R-packages/covidcast/vignettes/covidcast.Rmd
@@ -9,6 +9,7 @@ vignette: >
 ---
 
 This package provides access to data frames of values from the [COVIDcast
+endpoint of the Epidata
 API](https://cmu-delphi.github.io/delphi-epidata/api/covidcast.html). Using the
 `covidcast_signal()` function, you can fetch any data you may be interested in
 analyzing, then use `plot.covidcast_signal()` to make plots and maps. Since the
@@ -77,6 +78,29 @@ cli <- covidcast_signal(data_source = "fb-survey", signal = "smoothed_cli",
                         start_day = "2020-05-01", end_day = "2020-05-07",
                         geo_type = "county", geo_value = "42003")
 knitr::kable(head(cli))
+```
+
+By default, this package submits queries to the API anonymously. All the
+examples in the package documentation are compatible with anonymous use of the
+API, but [there are some limits on anonymous
+queries](https://cmu-delphi.github.io/delphi-epidata/api/api_keys.html) which do
+not apply if you use an API key to authenticate your queries. If you regularly
+or frequently use our system, please consider [registering for a free API
+key](https://forms.gle/hkBr5SfQgxguAfEt7) even if your usage falls within the
+anonymous usage limits. API key usage helps us understand who and how others are
+using our Delphi Epidata API, which may in turn inform our future research, data
+partnerships, and funding. If you do have an API key, you can use it with this
+package by setting the `covidcast.auth` option, then call fetch functions as
+normal:
+
+```{r, eval=FALSE}
+options(covidcast.auth = "your_api_key")
+
+cli <- suppressMessages(
+  covidcast_signal(data_source = "fb-survey", signal = "smoothed_cli",
+                   start_day = "2020-05-01", end_day = "2020-05-07",
+                   geo_type = "state")
+)
 ```
 
 ### Plotting and mapping

--- a/R-packages/covidcast/vignettes/multi-signals.Rmd
+++ b/R-packages/covidcast/vignettes/multi-signals.Rmd
@@ -27,7 +27,7 @@ signals <- covidcast_signals(data_source = "usa-facts",
                              signal = c("confirmed_incidence_num",
                                         "deaths_incidence_num"),
                              start_day = start_day, end_day = end_day,
-                             geo_type = "state")
+                             geo_type = "state", geo_values = "pa")
 
 summary(signals[[1]])
 summary(signals[[2]])


### PR DESCRIPTION
Preparing changes to be released before rollout of Epidata API Keys.

This PR makes the following changes:

* Python client
  * add `use_api_key` as a pass-through to the delphi-epidata python client, which handles keys through a class member
  * update package documentation overview warning (this turned into a wall of text, but I'd like to retain the appeal to register if we can -- open to ideas)
  * update package documentation getting-started with instructions for applying an API key to requests
  * update documentation build process & instructions, which had lost sync
* R client
  * add Authorization:Bearer headers using `getOptions`
  * update package documentation getting-started with instructions for applying an API key to requests
  * update package documentation multi-signals example to not require an API key to replicate

<details><summary>Checklist from draft mode</summary>

* [x] Add documentation for setting API key in the R client
* [x] Add documentation for setting API key in the Python client
* [x] Change R vignettes to be anonymous-request -compliant ([multi-signals.Rmd](https://github.com/cmu-delphi/covidcast/blob/e76f19dbc761620ca40bd276a058cbadc54d0243/R-packages/covidcast/vignettes/multi-signals.Rmd); all others checked exhaustively)
* [x] Check Python docs to be anonymous-request -compliant
* [x] Rebuild R docs -- not committing them here since that seems to be part of the release process; [R docs preview](http://rinkitink.ml.cmu.edu/covidcast/covidcastR/)
* [x] Rebuild Sphinx docs -- not committing them here; [Python docs preview](http://rinkitink.ml.cmu.edu/covidcast/covidcast-py/html/)

</details>