### PR TITLE
Use reframe() instead of summarize() for multiple rows

### DIFF
--- a/R-packages/covidcast/R/cor.R
+++ b/R-packages/covidcast/R/cor.R
@@ -66,13 +66,12 @@ covidcast_cor <- function(x, y, dt_x = 0, dt_y = 0,
   # Make sure that we have a complete record of dates for each geo_value (fill
   # with NAs as necessary)
   z_all <- dplyr::group_by(z, .data$geo_value)
-  z_all <- dplyr::summarize(z_all,
-                            time_value = seq.Date(
-                              as.Date(min(.data$time_value)),
-                              as.Date(max(.data$time_value)),
-                              by = "day")
-                            )
-  z_all <- dplyr::ungroup(z_all)
+  z_all <- dplyr::reframe(z_all,
+                          time_value = seq.Date(
+                            as.Date(min(.data$time_value)),
+                            as.Date(max(.data$time_value)),
+                            by = "day")
+                          )
 
   z <- dplyr::full_join(z, z_all, by = c("geo_value", "time_value"))
 

--- a/R-packages/covidcast/R/wrangle.R
+++ b/R-packages/covidcast/R/wrangle.R
@@ -58,13 +58,13 @@ apply_shifts_one <- function(x, dt) {
 
   # Make sure that we have a complete record of dates for each geo_value (fill
   # with NAs as necessary)
-  x_all <- x %>% dplyr::group_by(.data$geo_value) %>%
-    dplyr::summarize(time_value = seq.Date(as.Date(min(.data$time_value)),
-                                           as.Date(max(.data$time_value)),
-                                           by = "day"),
-                     data_source = .data$data_source[1],
-                     signal = .data$signal[1]) %>%
-    dplyr::ungroup()
+  x_all <- x %>%
+    dplyr::group_by(.data$geo_value) %>%
+    dplyr::reframe(time_value = seq.Date(as.Date(min(.data$time_value)),
+                                         as.Date(max(.data$time_value)),
+                                         by = "day"),
+                   data_source = .data$data_source[1],
+                   signal = .data$signal[1])
   x <- dplyr::full_join(
     x, x_all, by = c("data_source", "signal", "geo_value", "time_value")
   )


### PR DESCRIPTION
Since dplyr 1.1.0, returning multiple rows from summarize() is deprecated, and you're supposed to use reframe() instead. These are our two use-cases, so switch them over.

I ran into this while updating an old presentation, and dplyr helpfully barfed the deprecation warning right into my slides. This should fix it.