### PR TITLE
Evalcast: set get_predictions default to parallel=FALSE

### DIFF
--- a/R-packages/evalcast/R/get_predictions.R
+++ b/R-packages/evalcast/R/get_predictions.R
@@ -39,7 +39,7 @@
 #'   to `forecaster()`. A common use case would be to pass the period ahead
 #'   (e.g. predict 1 day, 2 days, ..., k days ahead). Note that `ahead` is a
 #'   required component of the forecaster output (see above).
-#' @param parallel_execution TRUE, FALSE, or a single positive integer. If TRUE,
+#' @param parallel_execution FALSE (default), TRUE, or a single positive integer. If TRUE,
 #'   executes each forecast date prediction in parallel on the number of
 #'   detected cores available minus 1. If FALSE, the code is run on a single
 #'   core. If integer, runs in parallel on that many cores, clipping to the

--- a/R-packages/evalcast/R/get_predictions.R
+++ b/R-packages/evalcast/R/get_predictions.R
@@ -85,7 +85,7 @@ get_predictions <- function(forecaster,
                             response_data_source = signals$data_source[1],
                             response_data_signal = signals$signal[1],
                             forecaster_args = list(),
-                            parallel_execution = TRUE,
+                            parallel_execution = FALSE,
                             additional_mclapply_args = list(),
                             honest_as_of = TRUE,
                             offline_signal_dir = NULL) {


### PR DESCRIPTION
Not sure why this was set to TRUE, but using parallelism for forecasting is quite tricky due to the many levels where it can be implemented. We've had too many times in production forecasting where eager parallelism settings at a lower level caused memory or other performance issues. Setting the default to FALSE is the safer option. 

Some things to look out for with this change:
- evalcast dashboard possibly becoming single-threaded and slow
- same for forecasting pipeline code

The CI is going to fail due to Python tests getting fixed in #620.