### PR TITLE
Fix Epidata.auth in covidcast.py

### DIFF
--- a/Python-packages/covidcast-py/covidcast/covidcast.py
+++ b/Python-packages/covidcast-py/covidcast/covidcast.py
@@ -34,7 +34,7 @@ def use_api_key(key):
     <https://cmu-delphi.github.io/delphi-epidata/api/api_keys.html>`_
     for details on our API key policies.
     """
-    Epidata.auth = key
+    Epidata.auth = ("epidata", key)
 
 def signal(data_source: str,
            signal: str,  # pylint: disable=W0621

--- a/Python-packages/covidcast-py/setup.py
+++ b/Python-packages/covidcast-py/setup.py
@@ -22,7 +22,7 @@ setuptools.setup(
     install_requires=[
         "pandas<2",
         "requests",
-        "delphi-epidata>=0.0.11",
+        "delphi-epidata>=4.1.1",
         "geopandas",
         "matplotlib",
         "numpy",


### PR DESCRIPTION
Epidata.auth should be tuple with "epidata" as first element. This change is done in order to make client to send proper request to the backend