### PR TITLE
Attempt at adding time_type arg

### DIFF
--- a/R-packages/covidcast/R/covidcast.R
+++ b/R-packages/covidcast/R/covidcast.R
@@ -560,6 +560,7 @@ covidcast_signals <- function(data_source, signal,
                                 "hhs",
                                 "nation"
                               ),
+                              time_type = c("day", "week"),
                               geo_values = "*",
                               as_of = NULL, issues = NULL, lag = NULL) {
   N <- max(length(data_source), length(signal))
@@ -595,6 +596,7 @@ covidcast_signals <- function(data_source, signal,
                                      start_day = start_day[i],
                                      end_day = end_day[i],
                                      geo_type = geo_type,
+                                     time_type = time_type,
                                      geo_values = geo_values,
                                      as_of = as_of, issues = issues,
                                      lag = lag)

--- a/R-packages/covidcast/man/covidcast_signals.Rd
+++ b/R-packages/covidcast/man/covidcast_signals.Rd
@@ -10,6 +10,7 @@ covidcast_signals(
   start_day = NULL,
   end_day = NULL,
   geo_type = c("county", "hrr", "msa", "dma", "state", "hhs", "nation"),
+  time_type = c("day", "week"),
   geo_values = "*",
   as_of = NULL,
   issues = NULL,
@@ -37,6 +38,10 @@ recent day data is available for this signal.}
 "county" or "state". Defaults to "county". See
 \url{https://cmu-delphi.github.io/delphi-epidata/api/covidcast_geography.html}
 for details on which types are available.}
+
+\item{time_type}{The temporal resolution to request this data. Most signals
+are available at the "day" resolution (the default); some are only
+available at the "week" resolution, representing an MMWR week ("epiweek").}
 
 \item{geo_values}{Which geographies to return. The default, "*", fetches all
 geographies. To fetch specific geographies, specify their IDs as a vector


### PR DESCRIPTION
I noticed that the documentation for `covidcast_signals()` says 

> The argument structure is just as in `covidcast_signal()`, except the first four arguments `data_source`, `signal`, `start_day`, `end_day` are permitted to be vectors.

However, `covidcast_signal()` has the keyword argument `time_type` and `covidcast_signals()` does not. When using `data_source = "nchs-mortality"`, you need to use `time_type = "week"` or it will error out. Hence, to call `covidcast_signals()` with `data_source = "nchs-mortality"`, we need to tell `covidcast_signal()` to use `time_type = "week"`.

Note: I'm having trouble getting the tests up and running locally, so I'm hoping the CI here will pick up any issues. Is there a suggested way to get the correct package versions?