### PR TITLE
Try to use GitHub PAT when fetching forecast dates; and check response status for rate limit

### DIFF
--- a/R-packages/evalcast/R/get_covidhub_predictions.R
+++ b/R-packages/evalcast/R/get_covidhub_predictions.R
@@ -491,7 +491,7 @@ is_rate_limit_exceeded <- function(response) {
     # Looks like "API rate limit exceeded for <IP address>. (But here's the
     # good news: Authenticated requests get a higher rate limit. Check out
     # the documentation for more details.)"
-    stop(paste("GitHub", httr::content(response) %>% purrr::pluck("message")))
+    stop(paste("The GitHub API request had a problem!", httr::content(response) %>% purrr::pluck("message")))
   }
   return(response)
 }


### PR DESCRIPTION
Followup to #647. Because dates are now being fetched using the GitHub API, scripts that request a lot of dates (e.g. forecast eval pipeline) can run into rate limits. When the API is rate-limited, `get_covidhub_forecast_dates` raises a non-informative warning and returns empty dates, causing downstream failures that are hard to debug.

Look for a `GITHUB_PAT` environment variable first, then `GITHUB_TOKEN` if `*_PAT` doesn't exist. If either is found, use it to authenticate the GET requests (using [this header format](https://docs.github.com/en/rest/overview/authenticating-to-the-rest-api?apiVersion=2022-11-28#about-authentication)). Response status codes are checked and if a 403 status is returned, the function exits with an error. It doesn't make sense to warn and return anyway because the results are empty; or to retry with backoff because the rate limit resets after an hour.

Note: I used the API's message as the error message because I'm not sure a 403-status is unique to reaching the rate limit and I want the actual error to be clear, and checking the text of the message wouldn't be robust.