### PR TITLE
Update CODEOWNERS for Katie's departure

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # default owners for anything not listed below, such as README and CI workflows
-* @krivard @capnrefsmmat
+* @rzats @capnrefsmmat
 
 # covidcast R package and data generation
 /R-packages/covidcast/ @capnrefsmmat
@@ -13,9 +13,6 @@
 
 # covidcast Python package
 /Python-packages/covidcast-py/ @chinandrew @capnrefsmmat
-
-# notebooks
-/R-notebooks/  @krivard
 
 # documentation changes go live instantly on GitHub.io, and hence require their
 # own review


### PR DESCRIPTION
* CI changes will be reviewed by Rostyslav
* Notebooks are no longer in use anywhere, so don't need a dedicated owner