### PR TITLE
Handle cases where `value` and `quantile` columns can't be read as numeric

### DIFF
--- a/R-packages/evalcast/R/get_covidhub_predictions.R
+++ b/R-packages/evalcast/R/get_covidhub_predictions.R
@@ -237,7 +237,8 @@ get_forecaster_predictions <- function(covidhub_forecaster_name,
                         forecast_date,
                         covidhub_forecaster_name)
     pred <- fread(filename,
-                  na.strings = c("\"NA\"", "NA"),
+                  # There are several different missing value encodings. Read them all as `NA`.
+                  na.strings = c("\"NA\"", "NA", "NULL", "\"NULL\"", "\"   NA\""),
                   colClasses = c(location = "character",
                                  quantile = "double",
                                  value = "double",


### PR DESCRIPTION
Format differences in forecaster input files means that `value` and `quantile` fields can't all be read as numeric. To avoid errors, read as character and cast to double later. Also specify several `NA`-equivalent values to get `get_forecaster_predictions` working in more cases and to avoid warnings when casting to double in `get_forecaster_predictions_alt`.

The `NA` addition fixes `get_forecaster_predictions` for 8 of the 10 forecasters where read fails for some dates. To fix the remaining failures (for `PSI-DRAFT` and `PSI-DICE` for some dates), apply the same character->double conversion as above.