### PR TITLE
Call `gc` during `_alt` forecast download function used for forecast eval pipeline

### DIFF
--- a/R-packages/evalcast/R/get_covidhub_predictions.R
+++ b/R-packages/evalcast/R/get_covidhub_predictions.R
@@ -413,6 +413,9 @@ get_forecaster_predictions_alt <- function(covidhub_forecaster_name,
   pcards <- filter(pcards, .data$signal %chin% !!signal)
   class(pcards) = c("predictions_cards", class(pcards))
 
+  # Try to free memory
+  invisible(gc())
+
   return(pcards)
 }
 


### PR DESCRIPTION
The `forecast-eval` pipeline is running out of memory. Try adding in some `gc()`s to free memory.

Note: There are other places that could be useful to call `gc()`, e.g. during scoring, during truth data fetch, but they would also impact non-forecast eval use. Given that calling `gc()` is a crude fix for OOM issues and that it would be nice for forecast eval to move away from `evalcast` , I don't want to go deep on this change. This is just an easy intervention on a "private" function.