### PR TITLE
Replace deprecated pkg_resources

### DIFF
--- a/Python-packages/covidcast-py/covidcast/covidcast.py
+++ b/Python-packages/covidcast-py/covidcast/covidcast.py
@@ -8,7 +8,7 @@ import pandas as pd
 import numpy as np
 from delphi_epidata import Epidata
 from delphi_epidata.delphi_epidata import _HEADERS
-from pkg_resources import get_distribution, DistributionNotFound
+from importlib.metadata import version, PackageNotFoundError
 from epiweeks import Week
 
 from .errors import NoDataWarning
@@ -18,8 +18,8 @@ from .errors import NoDataWarning
 Epidata.BASE_URL = "https://api.covidcast.cmu.edu/epidata"
 # Prepend to Epidata client's user agent to specify this package and version
 try:
-    _ver = get_distribution("covidcast").version
-except DistributionNotFound:
+    _ver = version("covidcast")
+except PackageNotFoundError:
     _ver = "0.0.0"
 _HEADERS['user-agent'] = f"covidcast/{_ver} " + _HEADERS['user-agent']
 

--- a/Python-packages/covidcast-py/covidcast/covidcast.py
+++ b/Python-packages/covidcast-py/covidcast/covidcast.py
@@ -3,12 +3,12 @@ import warnings
 from datetime import timedelta, date
 from functools import reduce
 from typing import Union, Iterable, Tuple, List
+from importlib.metadata import version, PackageNotFoundError
 
 import pandas as pd
 import numpy as np
 from delphi_epidata import Epidata
 from delphi_epidata.delphi_epidata import _HEADERS
-from importlib.metadata import version, PackageNotFoundError
 from epiweeks import Week
 
 from .errors import NoDataWarning

--- a/Python-packages/covidcast-py/covidcast/geography.py
+++ b/Python-packages/covidcast-py/covidcast/geography.py
@@ -4,14 +4,19 @@ import warnings
 from typing import Union, Iterable
 
 import pandas as pd
-import pkg_resources
+import importlib_resources
 
-COUNTY_CENSUS = pd.read_csv(
-    pkg_resources.resource_filename(__name__, "geo_mappings/county_census.csv"), dtype=str)
-MSA_CENSUS = pd.read_csv(
-    pkg_resources.resource_filename(__name__, "geo_mappings/msa_census.csv"), dtype=str)
-STATE_CENSUS = pd.read_csv(
-    pkg_resources.resource_filename(__name__, "geo_mappings/state_census.csv"), dtype=str)
+county_census = importlib_resources.files(__name__) / 'geo_mappings' / 'county_census.csv'
+with importlib_resources.as_file(county_census) as path:
+    COUNTY_CENSUS = pd.read_csv(path, dtype=str)
+
+msa_census = importlib_resources.files(__name__) / 'geo_mappings' / 'msa_census.csv'
+with importlib_resources.as_file(msa_census) as path:
+    MSA_CENSUS = pd.read_csv(path, dtype=str)
+
+state_census = importlib_resources.files(__name__) / 'geo_mappings' / 'state_census.csv'
+with importlib_resources.as_file(state_census) as path:
+    STATE_CENSUS = pd.read_csv(path, dtype=str)
 
 # Filter undesired rows from CSVs.
 # They're not removed from the files to keep them identical to rda files.

--- a/Python-packages/covidcast-py/covidcast/plotting.py
+++ b/Python-packages/covidcast-py/covidcast/plotting.py
@@ -9,7 +9,7 @@ import geopandas as gpd
 import imageio
 import numpy as np
 import pandas as pd
-import pkg_resources
+import importlib_resources
 from matplotlib import pyplot as plt
 from matplotlib import figure, axes
 from tqdm import tqdm
@@ -182,8 +182,9 @@ def get_geo_df(data: pd.DataFrame,
         raise ValueError("Unsupported geography type; "
                          "only `state`, `county`, `hrr`, and `msa` supported.")
 
-    shapefile_path = pkg_resources.resource_filename(__name__, SHAPEFILE_PATHS[geo_type])
-    geo_info = gpd.read_file(shapefile_path)
+    shapefile = importlib_resources.files(__name__) / SHAPEFILE_PATHS[geo_type]
+    with importlib_resources.as_file(shapefile) as shapefile_path:
+        geo_info = gpd.read_file(shapefile_path)
 
     if geo_type == "state":
         output = _join_state_geo_df(data, geo_value_col, geo_info, join_type)
@@ -294,8 +295,9 @@ def _plot_background_states(figsize: tuple) -> tuple:
     """
     fig, ax = plt.subplots(1, figsize=figsize)
     ax.axis("off")
-    state_shapefile_path = pkg_resources.resource_filename(__name__, SHAPEFILE_PATHS["state"])
-    state = gpd.read_file(state_shapefile_path)
+    state_shapefile = importlib_resources.files(__name__) / SHAPEFILE_PATHS["state"]
+    with importlib_resources.as_file(state_shapefile) as state_shapefile_path:
+      state = gpd.read_file(state_shapefile_path)
     for state in _project_and_transform(state, "STATEFP"):
         state.plot(color="0.9", ax=ax, edgecolor="0.8", linewidth=0.5)
     ax.set_xlim(plt.xlim())

--- a/Python-packages/covidcast-py/covidcast/plotting.py
+++ b/Python-packages/covidcast-py/covidcast/plotting.py
@@ -297,7 +297,7 @@ def _plot_background_states(figsize: tuple) -> tuple:
     ax.axis("off")
     state_shapefile = importlib_resources.files(__name__) / SHAPEFILE_PATHS["state"]
     with importlib_resources.as_file(state_shapefile) as state_shapefile_path:
-      state = gpd.read_file(state_shapefile_path)
+        state = gpd.read_file(state_shapefile_path)
     for state in _project_and_transform(state, "STATEFP"):
         state.plot(color="0.9", ax=ax, edgecolor="0.8", linewidth=0.5)
     ax.set_xlim(plt.xlim())

--- a/Python-packages/covidcast-py/setup.py
+++ b/Python-packages/covidcast-py/setup.py
@@ -30,7 +30,8 @@ setuptools.setup(
         "imageio-ffmpeg",
         "imageio",
         "tqdm",
-        "epiweeks"
+        "epiweeks",
+        "importlib_resources==6.1.1",
     ],
     package_data={"covidcast": ["shapefiles/*/*", "geo_mappings/*"]}
 )

--- a/Python-packages/covidcast-py/setup.py
+++ b/Python-packages/covidcast-py/setup.py
@@ -31,7 +31,7 @@ setuptools.setup(
         "imageio",
         "tqdm",
         "epiweeks",
-        "importlib_resources==6.1.1",
+        "importlib_resources>=1.3",
     ],
     package_data={"covidcast": ["shapefiles/*/*", "geo_mappings/*"]}
 )


### PR DESCRIPTION
Closes #666.

### Summary:

Removes uses of setuptools' deprecated `pkg_resources` library - these are replaced by the native `importlib.metadata` library, but also the `importlib_resources` backport. This is due to the features needed in the codebase, like [accessing resources within subdirectories](https://gitlab.com/python-devs/importlib_resources/-/issues/58), only becoming available in Python 3.9+.

### Prerequisites:

- [X] Unless it is a documentation hotfix it should be merged against the `dev` branch
- [X] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [X] Build is successful
- [X] Code is cleaned up and formatted
